### PR TITLE
[DS-274][fix] 增加Zookeeper参数单位说明

### DIFF
--- a/datasophon-api/src/main/resources/meta/DDP-1.1.1/ZOOKEEPER/service_ddl.json
+++ b/datasophon-api/src/main/resources/meta/DDP-1.1.1/ZOOKEEPER/service_ddl.json
@@ -128,7 +128,7 @@
     },
     {
       "name": "tickTime",
-      "label": "心跳时间",
+      "label": "心跳时间(毫秒)",
       "description": "Zookeeper服务器与客户端心跳时间，单位毫秒",
       "required": true,
       "type": "input",
@@ -139,7 +139,7 @@
     },
     {
       "name": "initLimit",
-      "label": "LF初始通信时限",
+      "label": "LF初始通信时限(tickTime的数量(次))",
       "description": "followers启动时需要连接leader，并从leader处获取它所缺失的那部分数据，以便它能和leader的数据保持同步。这个配置项限定从follower启动到恢复完成的超时时间。",
       "required": true,
       "type": "input",
@@ -150,7 +150,7 @@
     },
     {
       "name": "syncLimit",
-      "label": "LF同步通信时限",
+      "label": "LF同步通信时限(tickTime的数量(次))",
       "description": "follower和leader之间数据延迟的最大时间长度。",
       "required": true,
       "type": "input",
@@ -161,7 +161,7 @@
     },
     {
       "name": "zkHeapSize",
-      "label": "ZK最大堆内存",
+      "label": "ZK最大堆内存(GB)",
       "description": "ZK最大堆内存",
       "configType": "map",
       "required": true,


### PR DESCRIPTION
增加Zookeeper参数单位说明
tickTime---心跳时间(毫秒)
initLimit---LF初始通信时限(tickTime的数量(次))
syncLimit---LF同步通信时限(tickTime的数量(次))
zkHeapSize---ZK最大堆内存(GB)
This closes #274

<!--Thanks very much for contributing to DataSophon. Please review https://datasophon.github.io/datasophon-website/docs/current/%E5%BC%80%E5%8F%91%E8%80%85%E6%8C%87%E5%8D%97/%E5%8F%82%E4%B8%8E%E8%B4%A1%E7%8C%AE/pull_request before opening a pull request.-->

## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added datasophon-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contains incompatible changes, you should also pull request the documentation to `https://github.com/datasophon/datasophon-website`
