### PR TITLE
[Fix-275][api] remove the host from the cache when delete the host

### DIFF
--- a/datasophon-api/src/main/java/com/datasophon/api/service/impl/ClusterHostServiceImpl.java
+++ b/datasophon-api/src/main/java/com/datasophon/api/service/impl/ClusterHostServiceImpl.java
@@ -33,6 +33,7 @@ import com.datasophon.common.cache.CacheUtils;
 import com.datasophon.common.command.ExecuteCmdCommand;
 import com.datasophon.common.command.GenerateHostPrometheusConfig;
 import com.datasophon.common.command.GenerateRackPropCommand;
+import com.datasophon.common.model.HostInfo;
 import com.datasophon.common.utils.Result;
 import com.datasophon.dao.entity.ClusterHostEntity;
 import com.datasophon.dao.entity.ClusterInfoEntity;
@@ -48,6 +49,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
@@ -156,6 +158,12 @@ public class ClusterHostServiceImpl extends ServiceImpl<ClusterHostMapper, Clust
         prometheusActor.tell(prometheusConfigCommand, ActorRef.noSender());
 
         this.removeById(hostId);
+
+        // remove the host from the cache
+        Map<String, HostInfo> map =
+            (Map<String, HostInfo>) CacheUtils.get(clusterCode + Constants.HOST_MAP);
+        map.remove(host.getHostname());
+
         return Result.success();
     }
 


### PR DESCRIPTION
<!--Thanks very much for contributing to DataSophon. Please review https://datasophon.github.io/datasophon-website/docs/current/%E5%BC%80%E5%8F%91%E8%80%85%E6%8C%87%E5%8D%97/%E5%8F%82%E4%B8%8E%E8%B4%A1%E7%8C%AE/pull_request before opening a pull request.-->

## Purpose of the pull request

Fix #275 

## Brief change log

remove the host from the cache after deleting the host from the db

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added datasophon-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->
