### PR TITLE
Fixed DorisFE errors displayed in prometheus

### DIFF
--- a/datasophon-api/src/main/java/com/datasophon/api/master/PrometheusActor.java
+++ b/datasophon-api/src/main/java/com/datasophon/api/master/PrometheusActor.java
@@ -273,7 +273,7 @@ public class PrometheusActor extends UntypedActor {
                                 + Constants.UNDERLINE
                                 + roleInstanceEntity.getServiceRoleName();
                 logger.info("jmxKey is {}", jmxKey);
-                if ("SRFE".equals(roleInstanceEntity.getServiceRoleName())) {
+                if ("SRFE".equals(roleInstanceEntity.getServiceRoleName()) || "DorisFE".equals(roleInstanceEntity.getServiceRoleName())) {
                     logger.info(ServiceRoleJmxMap.get(jmxKey));
                     feList.add(
                             roleInstanceEntity.getHostname() + ":" + ServiceRoleJmxMap.get(jmxKey));


### PR DESCRIPTION
After doris is installed, prometheus does not display fe correctly, it is displayed in be

## Purpose of the pull request
DorisFe correctly displays in Prometheus

## Brief change log

PrometheusActor Adds a judgment

## Verify this pull request
This pull request is code cleanup without any test coverage.
