### PR TITLE
[Feature-372]The default value is hive on yarn

### DIFF
--- a/datasophon-api/src/main/resources/meta/DDP-1.1.3/HDFS/service_ddl.json
+++ b/datasophon-api/src/main/resources/meta/DDP-1.1.3/HDFS/service_ddl.json
@@ -1,1002 +1,245 @@
 {
-  "name": "HDFS",
-  "label": "HDFS",
-  "description": "分布式大数据存储",
-  "version": "3.3.3",
-  "sortNum": 1,
-  "dependencies": [
-    "ZOOKEEPER"
-  ],
-  "packageName": "hadoop-3.3.3.tar.gz",
-  "decompressPackageName": "hadoop-3.3.3",
+  "name": "DORIS",
+  "label": "Doris",
+  "description": "简单易用、高性能和统一的分析数据库",
+  "version": "1.2.6",
+  "sortNum": 20,
+  "dependencies":[],
+  "packageName": "doris-1.2.6.tar.gz",
+  "decompressPackageName": "doris-1.2.6",
   "roles": [
     {
-      "name": "JournalNode",
-      "label": "JournalNode",
+      "name": "DorisFE",
+      "label": "DorisFE",
       "roleType": "master",
-      "runAs": {
-        "user": "hdfs",
-        "group": "hadoop"
-      },
       "cardinality": "1+",
-      "sortNum": 1,
-      "logFile": "${hadoopLogDir}/hadoop-hdfs-journalnode-${host}.log",
-      "jmxPort": 27003,
+      "logFile": "fe/log/fe.log",
+      "jmxPort": 18030,
       "startRunner": {
         "timeout": "60",
-        "program": "control_hadoop.sh",
+        "program": "fe/bin/start_fe.sh",
         "args": [
-          "start",
-          "journalnode"
+          "--daemon"
         ]
       },
       "stopRunner": {
         "timeout": "600",
-        "program": "control_hadoop.sh",
+        "program": "fe/bin/stop_fe.sh",
         "args": [
-          "stop",
-          "journalnode"
+          "--daemon"
         ]
       },
       "statusRunner": {
         "timeout": "60",
-        "program": "control_hadoop.sh",
+        "program": "fe/bin/status_fe.sh",
         "args": [
           "status",
-          "journalnode"
-        ]
-      }
-    },
-    {
-      "name": "NameNode",
-      "label": "NameNode",
-      "roleType": "master",
-      "runAs": {
-        "user": "hdfs",
-        "group": "hadoop"
-      },
-      "cardinality": "1+",
-      "sortNum": 2,
-      "logFile": "${hadoopLogDir}/hadoop-hdfs-namenode-${host}.log",
-      "jmxPort": "27001",
-      "startRunner": {
-        "timeout": "60",
-        "program": "control_hadoop.sh",
-        "args": [
-          "start",
-          "namenode"
-        ]
-      },
-      "stopRunner": {
-        "timeout": "600",
-        "program": "control_hadoop.sh",
-        "args": [
-          "stop",
-          "namenode"
-        ]
-      },
-      "statusRunner": {
-        "timeout": "60",
-        "program": "control_hadoop.sh",
-        "args": [
-          "status",
-          "namenode"
-        ]
-      },
-      "restartRunner": {
-        "timeout": "60",
-        "program": "control_hadoop.sh",
-        "args": [
-          "restart",
-          "namenode"
+          "fe"
         ]
       },
       "externalLink": {
-        "name": "NameNode Ui",
-        "label": "NameNode Ui",
-        "url": "http://${host}:9870"
+        "name": "FE UI",
+        "label": "FE UI",
+        "url": "http://${host}:18030"
       }
     },
     {
-      "name": "DataNode",
-      "label": "DataNode",
+      "name": "DorisBE",
+      "label": "DorisBE",
       "roleType": "worker",
-      "runAs": {
-        "user": "hdfs",
-        "group": "hadoop"
-      },
       "cardinality": "1+",
-      "sortNum": 4,
-      "logFile": "${hadoopLogDir}/hadoop-hdfs-datanode-${host}.log",
-      "jmxPort": "27002",
+      "logFile": "be/log/be.INFO",
+      "jmxPort": 18040,
       "startRunner": {
         "timeout": "60",
-        "program": "control_hadoop.sh",
+        "program": "be/bin/start_be.sh",
         "args": [
-          "start",
-          "datanode"
+          "--daemon"
         ]
       },
       "stopRunner": {
         "timeout": "600",
-        "program": "control_hadoop.sh",
+        "program": "be/bin/stop_be.sh",
         "args": [
-          "stop",
-          "datanode"
+          "--daemon"
         ]
       },
       "statusRunner": {
         "timeout": "60",
-        "program": "control_hadoop.sh",
+        "program": "be/bin/status_be.sh",
         "args": [
           "status",
-          "datanode"
+          "be"
         ]
-      }
-    },
-    {
-      "name": "ZKFC",
-      "label": "ZKFC",
-      "roleType": "master",
-      "runAs": {
-        "user": "hdfs",
-        "group": "hadoop"
-      },
-      "cardinality": "1+",
-      "sortNum": 3,
-      "logFile": "${hadoopLogDir}/hadoop-hdfs-zkfc-${host}.log",
-      "jmxPort": 27004,
-      "startRunner": {
-        "timeout": "60",
-        "program": "control_hadoop.sh",
-        "args": [
-          "start",
-          "zkfc"
-        ]
-      },
-      "stopRunner": {
-        "timeout": "600",
-        "program": "control_hadoop.sh",
-        "args": [
-          "stop",
-          "zkfc"
-        ]
-      },
-      "statusRunner": {
-        "timeout": "60",
-        "program": "control_hadoop.sh",
-        "args": [
-          "status",
-          "zkfc"
-        ]
-      }
-    },
-    {
-      "name": "HdfsClient",
-      "label": "HdfsClient",
-      "roleType": "client",
-      "cardinality": "1+",
-      "runAs": {
-        "user": "hdfs",
-        "group": "hadoop"
       }
     }
   ],
   "configWriter": {
     "generators": [
       {
-        "filename": "core-site.xml",
-        "configFormat": "xml",
-        "outputDirectory": "etc/hadoop/",
+        "filename": "be.conf",
+        "configFormat": "properties",
+        "outputDirectory": "be/conf",
         "includeParams": [
-          "fs.defaultFS",
-          "hadoop.proxyuser.hive.hosts",
-          "hadoop.proxyuser.hive.groups",
-          "hadoop.proxyuser.hive.users",
-          "hadoop.http.staticuser.user",
-          "ha.zookeeper.quorum",
-          "hadoop.tmp.dir",
-          "net.topology.script.file.name",
-          "hadoop.security.authentication",
-          "hadoop.security.authorization",
-          "hadoop.security.auth_to_local.mechanism",
-          "hadoop.security.auth_to_local",
-          "hadoop.rpc.protection",
-          "custom.core.site.xml"
+          "be_priority_networks",
+          "sys_log_level",
+          "be_port",
+          "webserver_port",
+          "brpc_port",
+          "storage_root_path",
+          "custom.be.conf"
         ]
       },
       {
-        "filename": "hadoop-env.sh",
+        "filename": "fe.conf",
         "configFormat": "custom",
-        "outputDirectory": "etc/hadoop/",
-        "templateName": "hadoop-env.ftl",
+        "outputDirectory": "fe/conf",
+        "templateName": "doris_fe.ftl",
         "includeParams": [
-          "hadoopLogDir",
-          "hadoopHome",
-          "datanodeHeapSize",
-          "namenodeHeapSize",
-          "custom.hadoop.env.sh"
-        ]
-      },
-      {
-        "filename": "hdfs-site.xml",
-        "configFormat": "xml",
-        "outputDirectory": "etc/hadoop/",
-        "includeParams": [
-          "dfs.replication",
-          "dfs.namenode.name.dir",
-          "dfs.namenode.checkpoint.dir",
-          "dfs.blocksize",
-          "dfs.namenode.handler.count",
-          "dfs.datanode.data.dir",
-          "dfs.nameservices",
-          "dfs.ha.namenodes.nameservice1",
-          "dfs.namenode.rpc-address.nameservice1.nn1",
-          "dfs.namenode.rpc-address.nameservice1.nn2",
-          "dfs.namenode.http-address.nameservice1.nn1",
-          "dfs.namenode.http-address.nameservice1.nn2",
-          "dfs.namenode.shared.edits.dir",
-          "dfs.ha.fencing.methods",
-          "dfs.ha.fencing.ssh.private-key-files",
-          "dfs.journalnode.edits.dir",
-          "dfs.permissions.enabled",
-          "dfs.ha.automatic-failover.enabled",
-          "dfs.client.failover.proxy.provider.nameservice1",
-          "dfs.block.access.token.enable",
-          "dfs.namenode.kerberos.principal",
-          "dfs.namenode.keytab.file",
-          "dfs.journalnode.kerberos.principal",
-          "dfs.journalnode.keytab.file",
-          "dfs.web.authentication.kerberos.principal",
-          "dfs.web.authentication.kerberos.keytab",
-          "dfs.datanode.kerberos.principal",
-          "dfs.datanode.keytab.file",
-          "dfs.http.policy",
-          "dfs.data.transfer.protection",
-          "custom.hdfs.site.xml",
-          "dfs.permissions",
-          "dfs.namenode.inode.attributes.provider.class",
-          "dfs.hosts",
-          "dfs.hosts.exclude",
-          "net.topology.table.file.name",
-          "net.topology.node.switch.mapping.impl",
-          "dfs.datanode.address",
-          "dfs.datanode.http.address"
-        ]
-      },
-      {
-        "filename": "install.properties",
-        "configFormat": "custom",
-        "outputDirectory": "ranger-hdfs-plugin",
-        "templateName": "ranger-hdfs.ftl",
-        "includeParams": [
-          "hadoopHome",
-          "rangerAdminUrl"
-        ]
-      },
-      {
-        "filename": "mapred-site.xml",
-        "configFormat": "xml",
-        "outputDirectory": "etc/hadoop/",
-        "includeParams": [
-          "custom.mapred-site.xml"
+          "cluster_id",
+          "meta_dir",
+          "rpc_port",
+          "query_port",
+          "fe_priority_networks",
+          "custom.fe.conf"
         ]
       }
     ]
   },
   "parameters": [
     {
-      "name": "fs.defaultFS",
-      "label": "NameNode地址",
-      "description": "NameNode地址",
+      "name": "cluster_id",
+      "label": "集群ID",
+      "description": "相同集群ID的FE/BE节点属于同一个集群",
       "required": true,
       "type": "input",
       "value": "",
       "configurableInWizard": true,
       "hidden": false,
-      "defaultValue": "hdfs://nameservice1"
+      "defaultValue": "1"
     },
     {
-      "name": "hadoop.tmp.dir",
-      "label": "Hadoop运行时文件存储目录",
-      "description": "Hadoop运行时文件存储目录",
-      "configType": "path",
+      "name": "meta_dir",
+      "label": "FE元数据的保存目录",
+      "description": "FE元数据的保存目录",
       "required": true,
       "type": "input",
       "value": "",
       "configurableInWizard": true,
       "hidden": false,
-      "defaultValue": "/data/tmp/hadoop"
+      "defaultValue": "${DORIS_HOME}/fe/doris-meta"
     },
     {
-      "name": "hadoop.http.staticuser.user",
-      "label": "HDFS网页登录使用静态用户名",
-      "description": "配置HDFS网页登录使用的静态用户",
+      "name": "rpc_port",
+      "label": "FE节点上Thrift服务器的端口",
+      "description": "FE 节点上 Thrift 服务器的端口。",
       "required": true,
       "type": "input",
       "value": "",
       "configurableInWizard": true,
       "hidden": false,
-      "defaultValue": "admin"
+      "defaultValue": "9020"
     },
     {
-      "name": "hadoop.proxyuser.hive.hosts",
-      "label": "允许通过代理访问的主机节点",
-      "description": "配置hive允许通过代理访问的主机节点",
+      "name": "query_port",
+      "label": "FE节点上MySQL服务器的端口",
+      "description": "FE 节点上 MySQL 服务器的端口",
       "required": true,
       "type": "input",
       "value": "",
       "configurableInWizard": true,
       "hidden": false,
-      "defaultValue": "*"
+      "defaultValue": "9030"
     },
     {
-      "name": "hadoop.proxyuser.hive.groups",
-      "label": "允许通过代理用户所属组",
-      "description": "配置hive允许通过代理用户所属组",
+      "name": "fe_priority_networks",
+      "label": "FE优先网段",
+      "description": "为那些有多个 IP 地址的服务器声明一个选择策略。\n请注意，最多应该有一个 IP 地址与此列表匹配。这是一个以分号分隔格式的列表，用 CIDR 表示法，例如 10.10.10.0/24。 如果没有匹配这条规则的ip，会随机选择一个。",
       "required": true,
       "type": "input",
       "value": "",
       "configurableInWizard": true,
       "hidden": false,
-      "defaultValue": "*"
+      "defaultValue": "0.0.0.0/24"
     },
     {
-      "name": "hadoop.proxyuser.hive.users",
-      "label": "允许通过代理的用户",
-      "description": "配置hive允许通过代理的用户",
+      "name": "be_priority_networks",
+      "label": "BE优先网段",
+      "description": "为那些有多个 IP 地址的服务器声明一个选择策略。\n请注意，最多应该有一个 IP 地址与此列表匹配。这是一个以分号分隔格式的列表，用 CIDR 表示法，例如 10.10.10.0/24。 如果没有匹配这条规则的ip，会随机选择一个。",
       "required": true,
       "type": "input",
       "value": "",
       "configurableInWizard": true,
       "hidden": false,
-      "defaultValue": "*"
+      "defaultValue": "0.0.0.0/24"
     },
     {
-      "name": "dfs.replication",
-      "label": "BLOCK副本数",
-      "description": "配置hdfs副本数量",
-      "configName": "dfs.replication",
+      "name": "sys_log_level",
+      "label": "BE服务日志级别",
+      "description": "",
       "required": true,
-      "type": "input",
+      "type": "select",
       "value": "",
       "configurableInWizard": true,
-      "hidden": false,
-      "defaultValue": "3"
-    },
-    {
-      "name": "dfs.namenode.name.dir",
-      "label": "NameNode数据存储目录",
-      "description": "用于配置NameNode数据存储目录",
-      "configType": "path",
-      "required": true,
-      "separator": ",",
-      "type": "multiple",
-      "value": [
-        "/data/dfs/nn"
+      "selectValue": [
+        "INFO",
+        "WARNING",
+        "ERROR",
+        "FATAL"
       ],
-      "configurableInWizard": true,
       "hidden": false,
-      "defaultValue": ""
+      "defaultValue": "INFO"
     },
     {
-      "name": "dfs.namenode.checkpoint.dir",
-      "label": "元数据checkpoint目录",
-      "description": "配置元数据checkpoint目录，当namenode故障退出需要重新恢复时，可以从secondary namenode的工作目录中将fsimage拷贝到namenode的工作目录，以恢复namenode的元数据",
+      "name": "be_port",
+      "label": "BE admin端口",
+      "description": "BE admin端口",
+      "required": true,
+      "type": "input",
+      "value": "",
+      "configurableInWizard": true,
+      "hidden": false,
+      "defaultValue": "9060"
+    },
+    {
+      "name": "webserver_port",
+      "label": "BE WebServer端口",
+      "description": "BE WebServer端口",
+      "required": true,
+      "type": "input",
+      "value": "",
+      "configurableInWizard": true,
+      "hidden": false,
+      "defaultValue": "18040"
+    },
+    {
+      "name": "brpc_port",
+      "label": "BE Rpc端口",
+      "description": "BE Rpc端口",
+      "required": true,
+      "type": "input",
+      "value": "",
+      "configurableInWizard": true,
+      "hidden": false,
+      "defaultValue": "8060"
+    },
+    {
+      "name": "storage_root_path",
+      "label": "BE数据存储目录",
+      "description": "BE数据存储目录，可配置多个，按分号分隔，例如/data1,medium:HDD;/data2,medium:SSD;/data3",
       "configType": "path",
+      "separator": ";",
       "required": true,
       "type": "input",
       "value": "",
       "configurableInWizard": true,
       "hidden": false,
-      "defaultValue": "/data/dfs/snn"
-    },
-    {
-      "name": "dfs.blocksize",
-      "label": "Block大小",
-      "description": "用于配置Block大小,可根据磁盘性能进行计算",
-      "configName": "dfs.blocksize",
-      "required": true,
-      "type": "input",
-      "value": "",
-      "configurableInWizard": true,
-      "hidden": false,
-      "defaultValue": "268435456"
-    },
-    {
-      "name": "dfs.namenode.handler.count",
-      "label": "NameNode处理线程池大小",
-      "description": "用于配置NameNode处理线程池大小",
-      "configName": "dfs.namenode.handler.count",
-      "required": true,
-      "minValue": 0,
-      "maxValue": 128,
-      "type": "slider",
-      "value": "",
-      "configurableInWizard": true,
-      "hidden": false,
-      "defaultValue": "16"
-    },
-    {
-      "name": "dfs.datanode.data.dir",
-      "label": "DataNode数据存储目录",
-      "description": "DataNode数据存储目录，可配置多个，按逗号分隔",
-      "configType": "path",
-      "required": true,
-      "separator": ",",
-      "type": "multiple",
-      "value": [
-        "/data/dfs/dn"
-      ],
-      "configurableInWizard": true,
-      "hidden": false,
-      "defaultValue": ""
+      "defaultValue": "/data/be/storage"
     },
 
     {
-      "name": "namenodeHeapSize",
-      "label": "NameNode堆内存大小",
-      "description": "配置NameNode堆内存大小",
-      "configType": "map",
-      "required": true,
-      "minValue": 0,
-      "maxValue": 256,
-      "type": "slider",
-      "value": "",
-      "unit": "GB",
-      "configurableInWizard": true,
-      "hidden": false,
-      "defaultValue": "8"
-    },
-    {
-      "name": "datanodeHeapSize",
-      "label": "DataNode堆内存大小",
-      "description": "配置DataNode堆内存大小",
-      "configType": "map",
-      "required": true,
-      "minValue": 0,
-      "maxValue": 256,
-      "type": "slider",
-      "value": "",
-      "unit": "GB",
-      "configurableInWizard": true,
-      "hidden": false,
-      "defaultValue": "8"
-    },
-    {
-      "name": "hadoopLogDir",
-      "label": "Hadoop日志文件目录",
-      "description": "配置Hadoop系统日志文件目录，目录将存放NameNode，DataNode,ResourceManager等服务的系统日志",
-      "configType": "map",
-      "required": true,
-      "type": "input",
-      "value": "",
-      "configurableInWizard": true,
-      "hidden": false,
-      "defaultValue": "${HADOOP_HOME}/logs"
-    },
-    {
-      "name": "dfs.nameservices",
-      "label": "集群名称",
-      "description": "集群名称",
-      "configType": "ha",
-      "required": true,
-      "type": "input",
-      "value": "",
-      "configurableInWizard": true,
-      "hidden": false,
-      "defaultValue": "nameservice1"
-    },
-    {
-      "name": "ha.zookeeper.quorum",
-      "label": "zk地址",
-      "description": "zk地址",
-      "configType": "ha",
-      "required": true,
-      "type": "input",
-      "value": "",
-      "configurableInWizard": true,
-      "hidden": false,
-      "defaultValue": "${zkUrls}"
-    },
-    {
-      "name": "dfs.ha.automatic-failover.enabled",
-      "label": "是否开启自动故障转移",
-      "description": "是否开启自动故障转移",
-      "configType": "ha",
-      "required": true,
-      "type": "input",
-      "value": "",
-      "configurableInWizard": true,
-      "hidden": false,
-      "defaultValue": "true"
-    },
-    {
-      "name": "dfs.ha.namenodes.nameservice1",
-      "label": "NameNode节点",
-      "description": "NameNode节点",
-      "configType": "ha",
-      "required": true,
-      "type": "input",
-      "value": "",
-      "configurableInWizard": true,
-      "hidden": false,
-      "defaultValue": "nn1,nn2"
-    },
-    {
-      "name": "dfs.namenode.rpc-address.nameservice1.nn1",
-      "label": "nn1的rpc通信地址",
-      "description": "nn1的rpc通信地址",
-      "configType": "ha",
-      "required": true,
-      "type": "input",
-      "value": "",
-      "configurableInWizard": true,
-      "hidden": false,
-      "defaultValue": "${nn1}:8020"
-    },
-    {
-      "name": "dfs.namenode.rpc-address.nameservice1.nn2",
-      "label": "nn2的rpc通信地址",
-      "description": "nn2的rpc通信地址",
-      "configType": "ha",
-      "required": true,
-      "type": "input",
-      "value": "",
-      "configurableInWizard": true,
-      "hidden": false,
-      "defaultValue": "${nn2}:8020"
-    },
-    {
-      "name": "dfs.namenode.http-address.nameservice1.nn1",
-      "label": "nn1的http通信地址",
-      "description": "nn1的rpc通信地址",
-      "configType": "ha",
-      "required": true,
-      "type": "input",
-      "value": "",
-      "configurableInWizard": true,
-      "hidden": false,
-      "defaultValue": "${nn1}:9870"
-    },
-    {
-      "name": "dfs.namenode.http-address.nameservice1.nn2",
-      "label": "nn2的http通信地址",
-      "description": "nn2的rpc通信地址",
-      "configType": "ha",
-      "required": true,
-      "type": "input",
-      "value": "",
-      "configurableInWizard": true,
-      "hidden": false,
-      "defaultValue": "${nn2}:9870"
-    },
-    {
-      "name": "dfs.namenode.shared.edits.dir",
-      "label": "NameNode元数据在JournalNode存放位置",
-      "description": "NameNode元数据在JournalNode存放位置",
-      "required": true,
-      "configType": "ha",
-      "type": "input",
-      "value": "",
-      "configurableInWizard": true,
-      "hidden": false,
-      "defaultValue": "qjournal://${journalNode1}:8485;${journalNode2}:8485;${journalNode3}:8485/nameservice1"
-    },
-    {
-      "name": "dfs.ha.fencing.methods",
-      "label": "隔离机制",
-      "description": "隔离机制",
-      "configType": "ha",
-      "required": true,
-      "type": "input",
-      "value": "",
-      "configurableInWizard": true,
-      "hidden": false,
-      "defaultValue": "shell(/bin/true)"
-    },
-    {
-      "name": "dfs.ha.fencing.ssh.private-key-files",
-      "label": "隔离机制所需的ssh密钥",
-      "description": "隔离机制所需的ssh密钥",
-      "configType": "ha",
-      "required": true,
-      "type": "input",
-      "value": "",
-      "configurableInWizard": true,
-      "hidden": false,
-      "defaultValue": "/root/.ssh/id_rsa"
-    },
-    {
-      "name": "dfs.journalnode.edits.dir",
-      "label": "journalnode存储目录",
-      "description": "journalnode存储目录",
-      "configType": "path",
-      "required": true,
-      "type": "input",
-      "value": "",
-      "configurableInWizard": true,
-      "hidden": false,
-      "defaultValue": "/data/dfs/jn"
-    },
-    {
-      "name": "dfs.datanode.address",
-      "label": "datanode地址",
-      "description": "",
-      "configType": "ha",
-      "required": true,
-      "type": "input",
-      "value": "",
-      "configurableInWizard": true,
-      "hidden": false,
-      "defaultValue": "0.0.0.0:1026"
-    },
-    {
-      "name": "dfs.datanode.http.address",
-      "label": "datanode http地址",
-      "description": "",
-      "configType": "ha",
-      "required": true,
-      "type": "input",
-      "value": "",
-      "configurableInWizard": true,
-      "hidden": false,
-      "defaultValue": "0.0.0.0:1025"
-    },
-    {
-      "name": "dfs.permissions.enabled",
-      "label": "开启权限检查",
-      "description": "是否开启权限检查",
-      "configType": "ha",
-      "required": true,
-      "type": "switch",
-      "value": "",
-      "configurableInWizard": true,
-      "hidden": false,
-      "defaultValue": true
-    },
-    {
-      "name": "enableRack",
-      "label": "开启机架感知",
-      "description": "开启机架感知",
-      "required": false,
-      "type": "switch",
-      "value": "",
-      "configurableInWizard": true,
-      "hidden": false,
-      "defaultValue": false
-    },
-    {
-      "name": "enableKerberos",
-      "label": "开启Kerberos认证",
-      "description": "开启Kerberos认证",
-      "required": false,
-      "type": "switch",
-      "value": false,
-      "configurableInWizard": true,
-      "hidden": false,
-      "defaultValue": false
-    },
-    {
-      "name": "dfs.client.failover.proxy.provider.nameservice1",
-      "label": "容错实现类",
-      "description": "容错实现类",
-      "configType": "ha",
-      "required": true,
-      "type": "input",
-      "value": "",
-      "configurableInWizard": true,
-      "hidden": false,
-      "defaultValue": "org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider"
-    },
-
-    {
-      "name": "dfs.permissions",
-      "label": "启用Ranger权限",
-      "description": "",
-      "configType": "permission",
-      "required": false,
-      "type": "switch",
-      "value": true,
-      "configurableInWizard": true,
-      "hidden": true,
-      "defaultValue": true
-    },
-    {
-      "name": "dfs.namenode.inode.attributes.provider.class",
-      "label": "RangerHdfs认证类",
-      "description": "",
-      "configType": "permission",
-      "required": false,
-      "type": "input",
-      "value": "org.apache.ranger.authorization.hadoop.RangerHdfsAuthorizer",
-      "configurableInWizard": true,
-      "hidden": true,
-      "defaultValue": "org.apache.ranger.authorization.hadoop.RangerHdfsAuthorizer"
-    },
-    {
-      "name": "rangerAdminUrl",
-      "label": "Ranger访问地址",
-      "description": "",
-      "required": false,
-      "configType": "map",
-      "type": "input",
-      "value": "",
-      "configurableInWizard": true,
-      "hidden": true,
-      "defaultValue": ""
-    },
-    {
-      "name": "dfs.hosts",
-      "label": "DataNode白名单",
-      "description": "",
-      "required": true,
-      "type": "input",
-      "value": "",
-      "configurableInWizard": true,
-      "hidden": false,
-      "defaultValue": "${INSTALL_PATH}/hadoop-3.3.3/etc/hadoop/whitelist"
-    },
-    {
-      "name": "dfs.hosts.exclude",
-      "label": "DataNode黑名单",
-      "description": "",
-      "required": true,
-      "type": "input",
-      "value": "",
-      "configurableInWizard": true,
-      "hidden": false,
-      "defaultValue": "${INSTALL_PATH}/hadoop-3.3.3/etc/hadoop/blacklist"
-    },
-    {
-      "name": "hadoop.security.authentication",
-      "label": "集群认证方式",
-      "description": "",
-      "configWithKerberos": true,
-      "required": false,
-      "configType": "kb",
-      "type": "input",
-      "value": "kerberos",
-      "configurableInWizard": true,
-      "hidden": true,
-      "defaultValue": "kerberos"
-    },
-    {
-      "name": "hadoop.security.authorization",
-      "label": "启用Hadoop集群授权管理",
-      "description": "",
-      "configWithKerberos": true,
-      "required": false,
-      "configType": "kb",
-      "type": "switch",
-      "value": true,
-      "configurableInWizard": true,
-      "hidden": true,
-      "defaultValue": true
-    },
-    {
-      "name": "hadoop.security.auth_to_local.mechanism",
-      "label": "Kerberos主体到系统用户的映射机制",
-      "description": "",
-      "configWithKerberos": true,
-      "required": false,
-      "configType": "kb",
-      "type": "input",
-      "value": "MIT",
-      "configurableInWizard": true,
-      "hidden": true,
-      "defaultValue": "MIT"
-    },
-    {
-      "name": "hadoop.security.auth_to_local",
-      "label": "Kerberos主体到系统用户的具体映射规则",
-      "description": "",
-      "configWithKerberos": true,
-      "required": false,
-      "configType": "kb",
-      "separator":"\n",
-      "type": "multiple",
-      "value": ["RULE:[2:$1/$2@$0]([ndj]n\\/.*@HADOOP\\.COM)s/.*/hdfs/","RULE:[2:$1/$2@$0]([rn]m\\/.*@HADOOP\\.COM)s/.*/yarn/","RULE:[2:$1/$2@$0](jhs\\/.*@HADOOP\\.COM)s/.*/mapred/","DEFAULT"],
-      "hidden": true,
-      "defaultValue": []
-    },
-    {
-      "name": "hadoop.rpc.protection",
-      "label": "Hadoop集群间RPC通讯",
-      "description": "",
-      "configWithKerberos": true,
-      "required": false,
-      "configType": "kb",
-      "type": "input",
-      "value": "authentication",
-      "configurableInWizard": true,
-      "hidden": true,
-      "defaultValue": "authentication"
-    },
-    {
-      "name": "dfs.block.access.token.enable",
-      "label": "访问DataNode数据块时需通过Kerberos认证",
-      "description": "",
-      "configWithKerberos": true,
-      "required": false,
-      "configType": "kb",
-      "type": "switch",
-      "value": true,
-      "configurableInWizard": true,
-      "hidden": true,
-      "defaultValue": true
-    },
-    {
-      "name": "dfs.namenode.kerberos.principal",
-      "label": "NameNode服务的Kerberos主体",
-      "description": "",
-      "configWithKerberos": true,
-      "required": false,
-      "configType": "kb",
-      "type": "input",
-      "value": "nn/_HOST@HADOOP.COM",
-      "configurableInWizard": true,
-      "hidden": true,
-      "defaultValue": "nn/_HOST@HADOOP.COM"
-    },
-    {
-      "name": "dfs.namenode.keytab.file",
-      "label": "NameNode服务的Kerberos密钥文件路径",
-      "description": "",
-      "configWithKerberos": true,
-      "required": false,
-      "configType": "kb",
-      "type": "input",
-      "value": "/etc/security/keytab/nn.service.keytab",
-      "configurableInWizard": true,
-      "hidden": true,
-      "defaultValue": "/etc/security/keytab/nn.service.keytab"
-    },
-    {
-      "name": "dfs.journalnode.kerberos.principal",
-      "label": "JournalNode服务的Kerberos主体",
-      "description": "",
-      "configWithKerberos": true,
-      "required": false,
-      "configType": "kb",
-      "type": "input",
-      "value": "jn/_HOST@HADOOP.COM",
-      "configurableInWizard": true,
-      "hidden": true,
-      "defaultValue": "jn/_HOST@HADOOP.COM"
-    },
-    {
-      "name": "dfs.journalnode.keytab.file",
-      "label": "JournalNode服务的Kerberos密钥文件路径",
-      "description": "",
-      "configWithKerberos": true,
-      "required": false,
-      "configType": "kb",
-      "type": "input",
-      "value": "/etc/security/keytab/jn.service.keytab",
-      "configurableInWizard": true,
-      "hidden": true,
-      "defaultValue": "/etc/security/keytab/jn.service.keytab"
-    },
-
-    {
-      "name": "dfs.web.authentication.kerberos.principal",
-      "label": "Hadoop Web UI服务的Kerberos主体",
-      "description": "",
-      "configWithKerberos": true,
-      "required": false,
-      "configType": "kb",
-      "type": "input",
-      "value": "HTTP/_HOST@HADOOP.COM",
-      "configurableInWizard": true,
-      "hidden": true,
-      "defaultValue": "HTTP/_HOST@HADOOP.COM"
-    },
-    {
-      "name": "dfs.web.authentication.keytab.file",
-      "label": "Hadoop Web UI服务的Kerberos密钥文件路径",
-      "description": "",
-      "configWithKerberos": true,
-      "required": false,
-      "configType": "kb",
-      "type": "input",
-      "value": "/etc/security/keytab/spnego.service.keytab",
-      "configurableInWizard": true,
-      "hidden": true,
-      "defaultValue": "/etc/security/keytab/spnego.service.keytab"
-    },
-
-    {
-      "name": "dfs.datanode.kerberos.principal",
-      "label": "DataNode服务的Kerberos主体",
-      "description": "",
-      "configWithKerberos": true,
-      "required": false,
-      "configType": "kb",
-      "type": "input",
-      "value": "dn/_HOST@HADOOP.COM",
-      "configurableInWizard": true,
-      "hidden": true,
-      "defaultValue": "dn/_HOST@HADOOP.COM"
-    },
-    {
-      "name": "dfs.datanode.keytab.file",
-      "label": "DataNode服务的Kerberos密钥文件路径",
-      "description": "",
-      "configWithKerberos": true,
-      "required": false,
-      "configType": "kb",
-      "type": "input",
-      "value": "/etc/security/keytab/dn.service.keytab",
-      "configurableInWizard": true,
-      "hidden": true,
-      "defaultValue": "/etc/security/keytab/dn.service.keytab"
-    },
-    {
-      "name": "dfs.data.transfer.protection",
-      "label": "配置DataNode数据传输保护策略为仅认证模式",
-      "description": "",
-      "configWithKerberos": true,
-      "required": false,
-      "configType": "kb",
-      "type": "input",
-      "value": "authentication",
-      "configurableInWizard": true,
-      "hidden": true,
-      "defaultValue": "authentication"
-    },
-    {
-      "name": "dfs.http.policy",
-      "label": "配置NameNode Web UI使用HTTPS协议",
-      "description": "",
-      "configWithKerberos": true,
-      "required": false,
-      "configType": "kb",
-      "type": "input",
-      "value": "HTTPS_ONLY",
-      "configurableInWizard": true,
-      "hidden": true,
-      "defaultValue": "HTTPS_ONLY"
-    },
-    {
-      "name": "net.topology.table.file.name",
-      "label": "net.topology.table.file.name",
-      "description": "",
-      "required": false,
-      "configType": "rack",
-      "type": "input",
-      "value": "${HADOOP_HOME}/etc/hadoop/rack.properties",
-      "configWithRack": true,
-      "hidden": true,
-      "defaultValue": "${HADOOP_HOME}/etc/hadoop/rack.properties"
-    },
-    {
-      "name": "net.topology.node.switch.mapping.impl",
-      "label": "net.topology.node.switch.mapping.impl",
-      "description": "",
-      "required": false,
-      "configType": "rack",
-      "type": "input",
-      "value": "org.apache.hadoop.net.TableMapping",
-      "configWithRack": true,
-      "hidden": true,
-      "defaultValue": "org.apache.hadoop.net.TableMapping"
-    },
-    {
-      "name": "hadoopHome",
-      "label": "HADOOP_HOME",
-      "description": "Hadoop的安装目录",
-      "required": true,
-      "configType": "map",
-      "type": "input",
-      "value": "${HADOOP_HOME}",
-      "configurableInWizard": true,
-      "hidden": false,
-      "defaultValue": "${HADOOP_HOME}"
-    },
-    {
-      "name": "custom.core.site.xml",
-      "label": "自定义配置core-site.xml",
+      "name": "custom.fe.conf",
+      "label": "自定义配置fe.conf",
       "description": "自定义配置",
       "configType": "custom",
       "required": false,
@@ -1007,32 +250,8 @@
       "defaultValue": ""
     },
     {
-      "name": "custom.hdfs.site.xml",
-      "label": "自定义配置hdfs-site.xml",
-      "description": "自定义配置",
-      "configType": "custom",
-      "required": false,
-      "type": "multipleWithKey",
-      "value": [],
-      "configurableInWizard": true,
-      "hidden": false,
-      "defaultValue": ""
-    },
-    {
-      "name": "custom.hadoop.env.sh",
-      "label": "自定义配置hadoop-env.sh",
-      "description": "自定义配置",
-      "configType": "custom",
-      "required": false,
-      "type": "multipleWithKey",
-      "value": [],
-      "configurableInWizard": true,
-      "hidden": false,
-      "defaultValue": ""
-    },
-    {
-      "name": "custom.mapred-site.xml",
-      "label": "自定义配置mapred-site.xml",
+      "name": "custom.be.conf",
+      "label": "自定义配置be.conf",
       "description": "自定义配置",
       "configType": "custom",
       "required": false,

--- a/datasophon-api/src/main/resources/meta/DDP-1.1.3/HDFS/service_ddl.json
+++ b/datasophon-api/src/main/resources/meta/DDP-1.1.3/HDFS/service_ddl.json
@@ -273,6 +273,14 @@
           "hadoopHome",
           "rangerAdminUrl"
         ]
+      },
+      {
+        "filename": "mapred-site.xml",
+        "configFormat": "xml",
+        "outputDirectory": "etc/hadoop/",
+        "includeParams": [
+          "custom.mapred-site.xml"
+        ]
       }
     ]
   },
@@ -1013,6 +1021,18 @@
     {
       "name": "custom.hadoop.env.sh",
       "label": "自定义配置hadoop-env.sh",
+      "description": "自定义配置",
+      "configType": "custom",
+      "required": false,
+      "type": "multipleWithKey",
+      "value": [],
+      "configurableInWizard": true,
+      "hidden": false,
+      "defaultValue": ""
+    },
+    {
+      "name": "custom.mapred-site.xml",
+      "label": "自定义配置mapred-site.xml",
       "description": "自定义配置",
       "configType": "custom",
       "required": false,

--- a/datasophon-api/src/main/resources/meta/DDP-1.1.3/HIVE/service_ddl.json
+++ b/datasophon-api/src/main/resources/meta/DDP-1.1.3/HIVE/service_ddl.json
@@ -143,7 +143,14 @@
           "hive.zookeeper.client.port",
           "hive.server2.thrift.bind.host",
           "hive.server2.thrift.port",
-          "custom.hive.site.xml"
+          "custom.hive.site.xml",
+          "mapreduce.framework.name",
+          "hive.execution.engine",
+          "hive.merge.mapfiles",
+          "hive.merge.mapredfiles",
+          "hive.merge.size.per.task",
+          "hive.merge.smallfiles.avgsize",
+          "hive.exec.submit.local.task.via.child"
         ]
       },
       {
@@ -290,7 +297,90 @@
       "hidden": false,
       "defaultValue": false
     },
-
+    {
+      "name": "mapreduce.framework.name",
+      "label": "mr执行引擎",
+      "description": "MapReduce作业是在哪种运行时框架下执行的",
+      "required": true,
+      "type": "select",
+      "value": "yarn",
+      "configurableInWizard": true,
+      "hidden": false,
+      "defaultValue": "yarn",
+      "selectValue" : ["local", "classic", "yarn"]
+    },
+    {
+      "name": "hive.execution.engine",
+      "label": "Hive执行引擎",
+      "description": "Hive执行引擎",
+      "required": true,
+      "type": "select",
+      "value": "mr",
+      "configurableInWizard": true,
+      "hidden": false,
+      "defaultValue": "mr",
+      "selectValue" : ["mr", "tez", "spark"]
+    },
+    {
+      "name": "hive.merge.mapfiles",
+      "label": "启用(Map-Only)小文件合并",
+      "description": "在 map-only 作业结束时合并小文件。如启用，将创建 map-only 作业以合并目标表/分区中的文件",
+      "required": true,
+      "configType": "map",
+      "type": "switch",
+      "value": true,
+      "configurableInWizard": true,
+      "hidden": false,
+      "defaultValue": true
+    },
+    {
+      "name": "hive.merge.mapredfiles",
+      "label": "启用(Map-Reduce)小文件合并",
+      "description": "在 map-reduce 作业结束时合并小文件。如启用，将创建 map-only 作业以合并目标表/分区中的文件",
+      "required": true,
+      "configType": "map",
+      "type": "switch",
+      "value": true,
+      "configurableInWizard": true,
+      "hidden": false,
+      "defaultValue": true
+    },
+    {
+      "name": "hive.merge.size.per.task",
+      "label": "合并后所需的文件大小",
+      "description": "合并后所需的文件大小。应大于 hive.merge.smallfiles.avgsize",
+      "required": true,
+      "configType": "map",
+      "type": "input",
+      "value": "268435456",
+      "configurableInWizard": true,
+      "hidden": false,
+      "defaultValue": "268435456"
+    },
+    {
+      "name": "hive.merge.smallfiles.avgsize",
+      "label": "小文件平均大小合并阈值",
+      "description": "当作业的平均输出文件大小小于此属性的值时，Hive 将启动额外的 map-only 作业来将输出文件合并成大文件。仅当 hive.merge.mapfiles 为 true 对map-only 作业执行，当 hive.merge.mapredfiles 为 true 时对 map-reduce 作业执行，以及当 hive.merge.sparkfiles 为 true 时对 Spark 作业执行",
+      "required": true,
+      "configType": "map",
+      "type": "input",
+      "value": "104857600",
+      "configurableInWizard": true,
+      "hidden": false,
+      "defaultValue": "104857600"
+    },
+    {
+      "name": "hive.exec.submit.local.task.via.child",
+      "label": "地任务是否单独启动进程",
+      "description": "决定本地任务（通常是mapjoin的哈希表生成阶段）是否在单独的JVM中运行",
+      "required": true,
+      "configType": "map",
+      "type": "switch",
+      "value": false,
+      "configurableInWizard": true,
+      "hidden": false,
+      "defaultValue": false
+    },
     {
       "name": "hive.server2.authentication",
       "label": "hive认证方式",


### PR DESCRIPTION
Add hive execution engine. The default value is hive on yarn

<!--Thanks very much for contributing to DataSophon. Please review https://datasophon.github.io/datasophon-website/docs/current/%E5%BC%80%E5%8F%91%E8%80%85%E6%8C%87%E5%8D%97/%E5%8F%82%E4%B8%8E%E8%B4%A1%E7%8C%AE/pull_request before opening a pull request.-->

## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added datasophon-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contains incompatible changes, you should also pull request the documentation to `https://github.com/datasophon/datasophon-website`
