### PR TITLE
[fix] Error in revision status check

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -42,4 +42,4 @@ jobs:
           ./mvnw -Pgoogle-mirror -B clean install \
                  -Dmaven.test.skip=true \
                  --no-snapshot-updates \
-                 -pl !datasophon-ui,!datasophon-api -am
+                 -pl !datasophon-ui,!datasophon-api,!datasophon-service -am


### PR DESCRIPTION
Because our project does not push jar packages in the central warehouse, the status check cannot get our local third-party jar packages.

In addition, it is recommended that the main branch code version is in the form of a snapshot.
for example
1.1.3-SNAPSHOT

