### PR TITLE
fix:fix doris-meta for fe that does not automatically redirect paths …

### DIFF
--- a/datasophon-api/src/main/resources/meta/DDP-1.1.3/DORIS/service_ddl.json
+++ b/datasophon-api/src/main/resources/meta/DDP-1.1.3/DORIS/service_ddl.json
@@ -155,6 +155,7 @@
       "name": "meta_dir",
       "label": "FE元数据的保存目录",
       "description": "FE元数据的保存目录",
+      "configType": "path",
       "required": true,
       "type": "input",
       "value": "",


### PR DESCRIPTION
In Datasophon version 1.2.0, when modifying the doris-meta storage path of doris' fe, the doris cluster will not be created successfully.
