### PR TITLE
[Feature-431] Upgrade streampark version to 2.1.1

### DIFF
--- a/datasophon-api/src/main/resources/meta/DDP-1.2.0/STREAMPARK/service_ddl.json
+++ b/datasophon-api/src/main/resources/meta/DDP-1.2.0/STREAMPARK/service_ddl.json
@@ -2,18 +2,18 @@
   "name": "STREAMPARK",
   "label": "StreamPark",
   "description": "流处理极速开发框架,流批一体&湖仓一体的云原生平台,一站式流处理计算平台",
-  "version": "1.2.3",
+  "version": "2.1.1",
   "sortNum": 13,
   "dependencies":[],
-  "packageName": "streampark-1.2.3.tar.gz",
-  "decompressPackageName": "streampark-1.2.3",
+  "packageName": "streampark-2.1.1.tar.gz",
+  "decompressPackageName": "streampark-2.1.1",
   "roles": [
     {
       "name": "StreamPark",
       "label": "StreamPark",
       "roleType": "master",
       "cardinality": "1",
-      "logFile": "logs/streamx.out",
+      "logFile": "logs/streampark.out",
       "jmxPort": 10086,
       "startRunner": {
         "timeout": "60",
@@ -29,17 +29,16 @@
       },
       "statusRunner": {
         "timeout": "60",
-        "program": "bin/streamx.sh",
+        "program": "bin/streampark.sh",
         "args": [
           "status"
         ]
       },
       "restartRunner": {
         "timeout": "60",
-        "program": "control.sh",
+        "program": "bin/streampark.sh",
         "args": [
-          "restart",
-          "api-server"
+          "restart"
         ]
       },
       "externalLink": {
@@ -61,7 +60,9 @@
           "username",
           "password",
           "serverPort",
-          "hadoopUserName"
+          "hadoopUserName",
+          "workspaceLocal",
+          "workspaceRemote"
         ]
       }
     ]
@@ -126,6 +127,30 @@
       "configurableInWizard": true,
       "hidden": false,
       "defaultValue": "root"
+    },
+    {
+      "name": "workspaceLocal",
+      "label": "StreamPark本地工作空间目录",
+      "description": "自行创建,用于存放项目源码,构建的目录等",
+      "configType": "map",
+      "required": true,
+      "type": "input",
+      "value": "",
+      "configurableInWizard": true,
+      "hidden": false,
+      "defaultValue": "/data/streampark/workspace"
+    },
+    {
+      "name": "workspaceRemote",
+      "label": "StreamPark HDFS工作空间目录",
+      "description": "HDFS工作空间目录",
+      "configType": "map",
+      "required": true,
+      "type": "input",
+      "value": "",
+      "configurableInWizard": true,
+      "hidden": false,
+      "defaultValue": "hdfs://nameservice1/streampark"
     }
   ]
 }

--- a/datasophon-worker/src/main/resources/templates/streampark.ftl
+++ b/datasophon-worker/src/main/resources/templates/streampark.ftl
@@ -11,84 +11,89 @@ logging:
   level:
     root: info
 
+knife4j:
+  enable: true
+  basic:
+    # basic authentication, used to access swagger-ui and doc
+    enable: false
+    username: admin
+    password: streampark
+
+springdoc:
+  api-docs:
+    enabled: true
+  swagger-ui:
+    path: /swagger-ui.html
+  packages-to-scan: org.apache.streampark.console
+
 spring:
-  application.name: streamx
-  mvc:
-    pathmatch:
-      matching-strategy: ant_path_matcher
-  devtools:
-    restart:
-      enabled: false
+  application.name: StreamPark
+  devtools.restart.enabled: false
+  mvc.pathmatch.matching-strategy: ant_path_matcher
   servlet:
     multipart:
       enabled: true
       max-file-size: 500MB
       max-request-size: 500MB
-  datasource:
-    dynamic:
-      # 是否开启 SQL日志输出，生产环境建议关闭，有性能损耗
-      p6spy: false
-      hikari:
-        connection-timeout: 30000
-        max-lifetime: 1800000
-        max-pool-size: 15
-        min-idle: 5
-        connection-test-query: select 1
-        pool-name: HikariCP-DS-POOL
-      # 配置默认数据源
-      primary: primary
-      datasource:
-        # 数据源-1，名称为 primary
-        primary:
-          username: ${username}
-          password: ${password}
-          driver-class-name: com.mysql.cj.jdbc.Driver
-          url: ${databaseUrl}
   aop.proxy-target-class: true
   messages.encoding: utf-8
   jackson:
     date-format: yyyy-MM-dd HH:mm:ss
     time-zone: GMT+8
+    deserialization:
+      fail-on-unknown-properties: false
   main:
     allow-circular-references: true
     banner-mode: off
-
+  mvc:
+    converters:
+      preferred-json-mapper: jackson
+  datasource:
+    username: ${username}
+    password: ${password}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ${databaseUrl}
 
 management:
   endpoints:
     web:
       exposure:
-        include: [ 'httptrace', 'metrics' ]
+        include: [ 'health', 'httptrace', 'metrics' ]
+  endpoint:
+    health:
+      enabled: true
+      show-details: always
+      probes:
+        enabled: true
+  health:
+    ldap:
+      enabled: false
 
-#mybatis plus 设置
-mybatis-plus:
-  type-aliases-package: com.streamxhub.streamx.console.*.entity
-  mapper-locations: classpath:mapper/*/*.xml
-  configuration:
-    jdbc-type-for-null: null
-  global-config:
-    db-config:
-      id-type: auto
-    # 关闭 mybatis-plus的 banner
-    banner: false
+streampark:
+  proxy:
+    # knox process address https://cdpsit02.example.cn:8443/gateway/cdp-proxy/yarn
+    yarn-url:
+    # lark alert proxy,default https://open.feishu.cn
+    lark-url:
+  yarn:
+    # default sample, or kerberos
+    http-auth: sample
 
-streamx:
   # HADOOP_USER_NAME
   hadoop-user-name: ${hadoopUserName}
-  # 本地的工作空间,用于存放项目源码,构建的目录等.
+  # local workspace, used to store source code and build dir etc.
   workspace:
-    local: /opt/datasophon/streampark-1.2.3/workspace
-    remote: hdfs://nameservice1/streamx   # support hdfs:///streamx/ 、 /streamx 、hdfs://host:ip/streamx/
+    local: ${workspaceLocal}
+    remote: ${workspaceRemote}   # support hdfs:///streamx/ 、 /streamx 、hdfs://host:ip/streamx/
 
-  # remote docker register namespace for streamx
+  # remote docker register namespace for streampark
   docker:
-    register:
-      image-namespace: streamx
     # instantiating DockerHttpClient
     http-client:
       max-connections: 10000
       connection-timeout-sec: 10000
       response-timeout-sec: 12000
+      docker-host: ""
 
   # flink-k8s tracking configuration
   flink-k8s:
@@ -109,25 +114,20 @@ streamx:
     exec-cron: 0 0 0/6 * * ?
 
   shiro:
-    # token有效期，单位秒
+    # token timeout, unit second
     jwtTimeOut: 86400
-    # 后端免认证接口 url
+    # backend authentication-free resources url
     anonUrl: >
-      /passport/**,
-      /systemName,
-      /user/check/**,
-      /websocket/**,
-      /metrics/**,
-      /index.html,
-      /assets/**,
-      /css/**,
-      /fonts/**,
-      /img/**,
-      /js/**,
-      /loading/**,
-      /*.js,
-      /*.png,
-      /*.jpg,
-      /*.less,
-      /
 
+ldap:
+  # Is ldap enabled? If so, please modify the urls
+  enable: false
+  ## AD server IP, default port 389
+  urls: ldap://99.99.99.99:389
+  ## Login Account
+  base-dn: dc=streampark,dc=com
+  username: cn=Manager,dc=streampark,dc=com
+  password: streampark
+  user:
+    identity-attribute: uid
+    email-attribute: mail

--- a/docs/zh/为DataSophon制作streampark-2.1.1安装包.md
+++ b/docs/zh/为DataSophon制作streampark-2.1.1安装包.md
@@ -1,0 +1,86 @@
+# 为DataSophon制作streampark-2.1.1安装包.md
+
+## 下载并解压streampark 2.1.1安装包
+```shell
+tar -xzvf apache-streampark_2.12-2.1.1-incubating-bin.tar.gz
+```
+
+## 修改安装包目录名称
+保持和service_ddl.json中 decompressPackageName 一致
+```shell
+mv apache-streampark_2.12-2.1.1-incubating-bin streampark-2.1.1
+```
+
+## 修改`streampark-2.1.1/bin/streampark.sh`文件
+
+- 在DEFAULT_OPTS(原249行)中增加prometheus_javaagent配置，如下：
+```shell
+DEFAULT_OPTS="""
+  -ea
+  -server
+  -javaagent:$APP_HOME/jmx/jmx_prometheus_javaagent-0.16.1.jar=10086:$APP_HOME/jmx/prometheus_config.yml
+  -Xms1024m
+  -Xmx1024m
+  -Xmn256m
+  -XX:NewSize=100m
+  -XX:+UseConcMarkSweepGC
+  -XX:CMSInitiatingOccupancyFraction=70
+  -XX:ThreadStackSize=512
+  -Xloggc:${APP_HOME}/logs/gc.log
+  """
+```
+
+- 在start函数中，`local workspace=...略`(原380行)下一行，增加 `mkdir-p $workspace`，如下 
+```shell
+  local workspace=$(echo "$conf_streampark_workspace_local" | sed 's/#.*$//g')
+  mkdir -p $workspace
+  if [[ ! -d $workspace ]]; then
+    echo_r "ERROR: streampark.workspace.local: \"$workspace\" is invalid path, Please reconfigure in application.yml"
+    echo_r "NOTE: \"streampark.workspace.local\" Do not set under APP_HOME($APP_HOME). Set it to a secure directory outside of APP_HOME.  "
+    exit 1;
+  fi
+  if [[ ! -w $workspace ]] || [[ ! -r $workspace ]]; then
+      echo_r "ERROR: streampark.workspace.local: \"$workspace\" Permission denied! "
+      exit 1;
+  fi
+```
+
+- 修改status函数(原582行)中增加`exit 1`,如下：
+```shell
+status() {
+  # shellcheck disable=SC2155
+  # shellcheck disable=SC2006
+  local PID=$(get_pid)
+  if [ $PID -eq 0 ]; then
+    echo_r "StreamPark is not running"
+    exit 1
+  else
+    echo_g "StreamPark is running pid is: $PID"
+  fi
+}
+```
+
+## 增加jmx文件夹
+```shell
+   cp jmx streampark-2.1.1
+```
+
+## copy mysql8驱动包至lib目录
+(streampark从某个版本后把mysql驱动包移除了)
+```shell
+cp mysql-connector-java-8.0.28.jar streampark-2.1.1/lib/
+```
+
+## copy streampark安装包内的 mysql-schema.sql 和 mysql-data.sql 脚本出来备用
+```shell
+cp streampark-2.1.1/script/schema/mysql-schema.sql ./streampark_mysql-schema.sql
+cp streampark-2.1.1/script/data/mysql-data.sql ./streampark_mysql-data.sql
+```
+
+## 打压缩包并生成md5
+```shell
+tar -czf  streampark-2.1.1.tar.gz   streampark-2.1.1
+md5sum streampark-2.1.1.tar.gz | awk '{print $1}' >streampark-2.1.1.tar.gz.md5
+```
+
+


### PR DESCRIPTION
## Purpose of the pull request
 Upgrade streampark version to 2.1.1

## Brief change log
- update service_ddl.json，add params: workspaceLocal、workspaceRemote
- update streampark.ftl，adapt to the version 2.1.1
- add doc， DataSophon制作streampark-2.1.1安装包.md

## Verify this pull request
This pull request is code cleanup without any test coverage.
I verified the installation process of streampark-2.1.1

