### PR TITLE
[improvement] disable flink dashboard and spark dashboard

### DIFF
--- a/datasophon-api/src/main/resources/db/migration/1.2.1/R1.2.1.sql
+++ b/datasophon-api/src/main/resources/db/migration/1.2.1/R1.2.1.sql
@@ -1,0 +1,2 @@
+INSERT INTO `t_ddh_cluster_service_dashboard` (`id`, `service_name`, `dashboard_url`) VALUES (11, 'SPARK3', 'http://${grafanaHost}:3000/d/rCUqf3dWz/7-spark?orgId=1&from=now-30m&to=now&refresh=5m&kiosk');
+INSERT INTO `t_ddh_cluster_service_dashboard` (`id`, `service_name`, `dashboard_url`) VALUES (15, 'FLINK', 'http://${grafanaHost}:3000/d/-0rFuzoZk/flink-dashboard?orgId=1&refresh=30s&kiosk');

--- a/datasophon-api/src/main/resources/db/migration/1.2.1/V1.2.1__DML.sql
+++ b/datasophon-api/src/main/resources/db/migration/1.2.1/V1.2.1__DML.sql
@@ -1,0 +1,1 @@
+DELETE FROM `t_ddh_cluster_service_dashboard` where `id` in (11, 13);


### PR DESCRIPTION
## Purpose of the pull request

disable flink dashboard and spark dashboard

## Brief change log

flink and spark is running on yarn by default , so their monitor will be cancel

## Verify this pull request

This pull request is code test in local env.

