### PR TITLE
Increase the maximum communication duration and solve the problem of …

### DIFF
--- a/datasophon-api/src/main/resources/meta/DDP-1.2.0/HDFS/service_ddl.json
+++ b/datasophon-api/src/main/resources/meta/DDP-1.2.0/HDFS/service_ddl.json
@@ -196,6 +196,7 @@
           "hadoop.http.staticuser.user",
           "ha.zookeeper.quorum",
           "hadoop.tmp.dir",
+          "ipc.client.connect.timeout",
           "net.topology.script.file.name",
           "hadoop.security.authentication",
           "hadoop.security.authorization",
@@ -235,6 +236,9 @@
           "dfs.namenode.rpc-address.nameservice1.nn2",
           "dfs.namenode.http-address.nameservice1.nn1",
           "dfs.namenode.http-address.nameservice1.nn2",
+          "dfs.qjournal.start-segment.timeout.ms",
+          "dfs.qjournal.select-input-streams.timeout.ms",
+          "dfs.qjournal.write-txns.timeout.ms",
           "dfs.namenode.shared.edits.dir",
           "dfs.ha.fencing.methods",
           "dfs.ha.fencing.ssh.private-key-files",
@@ -299,6 +303,18 @@
       "configurableInWizard": true,
       "hidden": false,
       "defaultValue": "/data/tmp/hadoop"
+    },
+    {
+      "name": "ipc.client.connect.timeout",
+      "label": "IPC通信",
+      "description": "IPC通信超时时间",
+      "configType": "ha",
+      "required": true,
+      "type": "input",
+      "value": "",
+      "configurableInWizard": true,
+      "hidden": false,
+      "defaultValue": "600000"
     },
     {
       "name": "hadoop.http.staticuser.user",
@@ -562,6 +578,42 @@
       "configurableInWizard": true,
       "hidden": false,
       "defaultValue": "${nn2}:9870"
+    },
+    {
+      "name": "dfs.qjournal.start-segment.timeout.ms",
+      "label": "qjournal的start-segment时间",
+      "description": "qjournal的start-segment超时时间",
+      "configType": "ha",
+      "required": true,
+      "type": "input",
+      "value": "",
+      "configurableInWizard": true,
+      "hidden": false,
+      "defaultValue": "600000"
+    },
+    {
+      "name": "dfs.qjournal.select-input-streams.timeout.ms",
+      "label": "qjournal的select-input-streams时间",
+      "description": "qjournal的select-input-streams超时时间",
+      "configType": "ha",
+      "required": true,
+      "type": "input",
+      "value": "",
+      "configurableInWizard": true,
+      "hidden": false,
+      "defaultValue": "600000"
+    },
+    {
+      "name": "dfs.qjournal.write-txns.timeout.ms",
+      "label": "qjournal的写入时间",
+      "description": "qjournal的写入超时时间",
+      "configType": "ha",
+      "required": true,
+      "type": "input",
+      "value": "",
+      "configurableInWizard": true,
+      "hidden": false,
+      "defaultValue": "600000"
     },
     {
       "name": "dfs.namenode.shared.edits.dir",


### PR DESCRIPTION
…the probability of failure during the first default installation of HDFS in Datasophon

<!--Thanks very much for contributing to DataSophon. Please review https://datasophon.github.io/datasophon-website/docs/current/%E5%BC%80%E5%8F%91%E8%80%85%E6%8C%87%E5%8D%97/%E5%8F%82%E4%B8%8E%E8%B4%A1%E7%8C%AE/pull_request before opening a pull request.-->
[Bug] [HDFS]In version 1.2.0, there is a probability that the first installation of HDFS will fail #470
## Purpose of the pull request
The differences in deployment environment resources and the length of time required for code execution and installation also vary. Therefore, increasing the maximum communication time of Hadoop can make it adapt to more installation environments as much as possible. This time, four parameters have been added to increase the maximum communication time
<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->



This pull request is already covered by existing tests



<!--*(example:)*
- *Added datasophon-infrastructure tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->


