### PR TITLE
Branch 1.2.0 upgrade hbase2.5.6

### DIFF
--- a/datasophon-api/src/main/resources/meta/DDP-1.2.0/HBASE/service_ddl.json
+++ b/datasophon-api/src/main/resources/meta/DDP-1.2.0/HBASE/service_ddl.json
@@ -2,11 +2,11 @@
   "name": "HBASE",
   "label": "HBase",
   "description": "分布式列式海量存储数据库",
-  "version": "2.4.16",
+  "version": "2.5.6",
   "sortNum": 8,
   "dependencies":["HDFS"],
-  "packageName": "hbase-2.4.16.tar.gz",
-  "decompressPackageName": "hbase-2.4.16",
+  "packageName": "hbase-2.5.6-zhtx.tar.gz",
+  "decompressPackageName": "hbase-2.5.6-zhtx",
   "runAs":"root",
   "roles": [
     {
@@ -113,6 +113,10 @@
           "hbase.rootdir",
           "hbase.zookeeper.quorum",
           "hbase.wal.provider",
+          "hbase.regionserver.wal.codec",
+          "phoenix.schema.isNamespaceMappingEnabled",
+          "hbase.io.compress.snappy.codec",
+          "hbase.table.sanity.checks",
           "hbase.unsafe.stream.capability.enforce",
           "hbase.security.authentication",
           "hbase.rpc.engine",
@@ -185,7 +189,7 @@
       "description": "hbase.zookeeper.quorum",
       "required": true,
       "type": "input",
-      "value": "${zkUrls}",
+      "value": "${hbaseZkUrls}",
       "configurableInWizard": true,
       "hidden": false,
       "defaultValue": ""
@@ -200,6 +204,50 @@
       "configurableInWizard": true,
       "hidden": false,
       "defaultValue": "filesystem"
+    },
+    {
+      "name": "hbase.regionserver.wal.codec",
+      "label": "hbase.regionserver.wal.codec",
+      "description": "hbase.regionserver.wal.codec",
+      "required": true,
+      "type": "input",
+      "value": "",
+      "configurableInWizard": true,
+      "hidden": false,
+      "defaultValue": "org.apache.hadoop.hbase.regionserver.wal.IndexedWALEditCodec"
+    },
+    {
+      "name": "phoenix.schema.isNamespaceMappingEnabled",
+      "label": "phoenix.schema.isNamespaceMappingEnabled",
+      "description": "phoenix.schema.isNamespaceMappingEnabled",
+      "required": true,
+      "type": "input",
+      "value": "",
+      "configurableInWizard": true,
+      "hidden": false,
+      "defaultValue": "true"
+    },
+    {
+      "name": "hbase.io.compress.snappy.codec",
+      "label": "hbase.io.compress.snappy.codec",
+      "description": "hbase.io.compress.snappy.codec",
+      "required": true,
+      "type": "input",
+      "value": "",
+      "configurableInWizard": true,
+      "hidden": false,
+      "defaultValue": "org.apache.hadoop.hbase.io.compress.xerial.SnappyCodec"
+    },
+    {
+      "name": "hbase.table.sanity.checks",
+      "label": "hbase.table.sanity.checks",
+      "description": "hbase.table.sanity.checks",
+      "required": true,
+      "type": "input",
+      "value": "",
+      "configurableInWizard": true,
+      "hidden": false,
+      "defaultValue": "false"
     },
     {
       "name": "hbase.unsafe.stream.capability.enforce",

--- a/datasophon-api/src/main/resources/meta/DDP-1.2.0/HDFS/service_ddl.json
+++ b/datasophon-api/src/main/resources/meta/DDP-1.2.0/HDFS/service_ddl.json
@@ -196,6 +196,7 @@
           "hadoop.http.staticuser.user",
           "ha.zookeeper.quorum",
           "hadoop.tmp.dir",
+          "ipc.client.connect.timeout",
           "net.topology.script.file.name",
           "hadoop.security.authentication",
           "hadoop.security.authorization",
@@ -235,6 +236,9 @@
           "dfs.namenode.rpc-address.nameservice1.nn2",
           "dfs.namenode.http-address.nameservice1.nn1",
           "dfs.namenode.http-address.nameservice1.nn2",
+          "dfs.qjournal.start-segment.timeout.ms",
+          "dfs.qjournal.select-input-streams.timeout.ms",
+          "dfs.qjournal.write-txns.timeout.ms",
           "dfs.namenode.shared.edits.dir",
           "dfs.ha.fencing.methods",
           "dfs.ha.fencing.ssh.private-key-files",
@@ -299,6 +303,18 @@
       "configurableInWizard": true,
       "hidden": false,
       "defaultValue": "/data/tmp/hadoop"
+    },
+    {
+      "name": "ipc.client.connect.timeout",
+      "label": "IPC通信",
+      "description": "IPC通信超时时间",
+      "configType": "ha",
+      "required": true,
+      "type": "input",
+      "value": "",
+      "configurableInWizard": true,
+      "hidden": false,
+      "defaultValue": "600000"
     },
     {
       "name": "hadoop.http.staticuser.user",
@@ -562,6 +578,42 @@
       "configurableInWizard": true,
       "hidden": false,
       "defaultValue": "${nn2}:9870"
+    },
+    {
+      "name": "dfs.qjournal.start-segment.timeout.ms",
+      "label": "qjournal的start-segment时间",
+      "description": "qjournal的start-segment超时时间",
+      "configType": "ha",
+      "required": true,
+      "type": "input",
+      "value": "",
+      "configurableInWizard": true,
+      "hidden": false,
+      "defaultValue": "600000"
+    },
+    {
+      "name": "dfs.qjournal.select-input-streams.timeout.ms",
+      "label": "qjournal的select-input-streams时间",
+      "description": "qjournal的select-input-streams超时时间",
+      "configType": "ha",
+      "required": true,
+      "type": "input",
+      "value": "",
+      "configurableInWizard": true,
+      "hidden": false,
+      "defaultValue": "600000"
+    },
+    {
+      "name": "dfs.qjournal.write-txns.timeout.ms",
+      "label": "qjournal的写入时间",
+      "description": "qjournal的写入超时时间",
+      "configType": "ha",
+      "required": true,
+      "type": "input",
+      "value": "",
+      "configurableInWizard": true,
+      "hidden": false,
+      "defaultValue": "600000"
     },
     {
       "name": "dfs.namenode.shared.edits.dir",

--- a/datasophon-service/src/main/java/com/datasophon/api/strategy/ZkServerHandlerStrategy.java
+++ b/datasophon-service/src/main/java/com/datasophon/api/strategy/ZkServerHandlerStrategy.java
@@ -48,6 +48,9 @@ public class ZkServerHandlerStrategy implements ServiceRoleStrategy {
         String join = String.join(":2181,", hosts);
         String zkUrls = join + ":2181";
         ProcessUtils.generateClusterVariable(globalVariables, clusterId, "${zkUrls}", zkUrls);
+        // 保存hbaseZkUrls到全局变量
+        String hbaseZkUrls=String.join(",", hosts);
+        ProcessUtils.generateClusterVariable(globalVariables, clusterId, "${hbaseZkUrls}", hbaseZkUrls);
 
     }
 

--- a/datasophon-worker/src/main/resources/script/datasophon-env.sh
+++ b/datasophon-worker/src/main/resources/script/datasophon-env.sh
@@ -7,7 +7,8 @@ export PYSPARK_ALLOW_INSECURE_GATEWAY=1
 export HIVE_HOME=/opt/datasophon/hive-3.1.0
 
 export KAFKA_HOME=/opt/datasophon/kafka-2.4.1
-export HBASE_HOME=/opt/datasophon/hbase-2.4.16
+export HBASE_HOME=/opt/datasophon/hbase-2.5.6-zhtx
+export HBASE_PID_PATH_MK=/opt/datasophon/hbase-2.5.6-zhtx/pid
 export FLINK_HOME=/opt/datasophon/flink-1.15.2
 export HADOOP_HOME=/opt/datasophon/hadoop-3.3.3
 export HADOOP_CONF_DIR=/opt/datasophon/hadoop-3.3.3/etc/hadoop

--- a/datasophon-worker/src/main/resources/templates/hbase-env.ftl
+++ b/datasophon-worker/src/main/resources/templates/hbase-env.ftl
@@ -70,6 +70,11 @@ export HBASE_OPTS="$HBASE_OPTS -XX:+UseConcMarkSweepGC <#if hbaseSecurity??>${hb
 # If FILE-PATH is not replaced, the log file(.gc) would still be generated in the HBASE_LOG_DIR .
 # export CLIENT_GC_OPTS="-verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:  -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=1 -XX:GCLogFileSize=512M"
 
+export HBASE_JMX_BASE="-Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false"
+
+export HBASE_MASTER_OPTS="$HBASE_MASTER_OPTS $HBASE_JMX_BASE  -javaagent:$HBASE_HOME/jmx/jmx_prometheus_javaagent-0.16.1.jar=16100:$HBASE_HOME/jmx/hbase_jmx_config.yaml"
+
+export HBASE_REGIONSERVER_OPTS="$HBASE_REGIONSERVER_OPTS $HBASE_JMX_BASE -javaagent:$HBASE_HOME/jmx/jmx_prometheus_javaagent-0.16.1.jar=16101:$HBASE_HOME/jmx/hbase_jmx_config.yaml"
 # See the package documentation for org.apache.hadoop.hbase.io.hfile for other configurations
 # needed setting up off-heap block caching. 
 


### PR DESCRIPTION
<!--Thanks very much for contributing to DataSophon. Please review https://datasophon.github.io/datasophon-website/docs/current/%E5%BC%80%E5%8F%91%E8%80%85%E6%8C%87%E5%8D%97/%E5%8F%82%E4%B8%8E%E8%B4%A1%E7%8C%AE/pull_request before opening a pull request.-->

## Purpose of the pull request
[Bug] [Hbase] Incompatibility issues with hbase2.4.16, hadoop 3.3.3, phoenix, failure to create snappy table, and inability to create phoenix index #472
<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log
1. Compile a new version of hbase, hbase-2.5.6-zhtx, and solve the following issues:

(1) Solve integration issues with datasophon components, enabling one click deployment and management

(2) Resolving the issue of hmaster having a probability of reboot failure during reboot

(3) Resolve the incompatibility issue between HBase and Hadoop, which means that the snappy table cannot be created

(4) Resolve compatibility issues with Phoenix, which means that Snappy tables and indexes cannot be created, making it compatible with Phoenix and able to create Snappy tables and indexes

2. Modify the hbase env.ftl of the dataset worker to enable the newly compiled hbase-2.5.6-zhtx version to be monitored in the dataset

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->


This pull request is already covered by existing tests in V1.2.0

<!--*(example:)*
- *Added datasophon-infrastructure tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->


