### PR TITLE
fix: replace datasophon env real path to link ISSUE 477

### DIFF
--- a/datasophon-worker/src/main/resources/script/datasophon-env.sh
+++ b/datasophon-worker/src/main/resources/script/datasophon-env.sh
@@ -2,16 +2,16 @@ export JAVA_HOME=/usr/local/jdk1.8.0_333
 CLASSPATH=.:$JAVA_HOME/lib/dt.jar:$JAVA_HOME/lib/tools.jar
 export JAVA_HOME CLASSPATH
 
-export KYUUBI_HOME=/opt/datasophon/kyuubi-1.7.3
-export SPARK_HOME=/opt/datasophon/spark-3.1.3
+export KYUUBI_HOME=/opt/datasophon/kyuubi
+export SPARK_HOME=/opt/datasophon/spark
 export PYSPARK_ALLOW_INSECURE_GATEWAY=1
-export HIVE_HOME=/opt/datasophon/hive-3.1.0
-export KAFKA_HOME=/opt/datasophon/kafka-2.4.1
-export HBASE_HOME=/opt/datasophon/hbase-2.5.6
-export HBASE_PID_PATH_MK=/opt/datasophon/hbase-2.5.6/pid
-export FLINK_HOME=/opt/datasophon/flink-1.16.2
-export HADOOP_HOME=/opt/datasophon/hadoop-3.3.3
-export HADOOP_CONF_DIR=/opt/datasophon/hadoop-3.3.3/etc/hadoop
+export HIVE_HOME=/opt/datasophon/hive
+export KAFKA_HOME=/opt/datasophon/kafka
+export HBASE_HOME=/opt/datasophon/hbase
+export HBASE_PID_PATH_MK=/opt/datasophon/hbase/pid
+export FLINK_HOME=/opt/datasophon/flink
+export HADOOP_HOME=/opt/datasophon/hadoop
+export HADOOP_CONF_DIR=/opt/datasophon/hadoop/etc/hadoop
 export PATH=$PATH:$JAVA_HOME/bin:$SPARK_HOME/bin:$HADOOP_HOME/bin:$HIVE_HOME/bin:$FLINK_HOME/bin:$KAFKA_HOME/bin:$HBASE_HOME/bin
 export HADOOP_CLASSPATH=`hadoop classpath`
 


### PR DESCRIPTION
<!--Thanks very much for contributing to DataSophon. Please review https://datasophon.github.io/datasophon-website/docs/current/%E5%BC%80%E5%8F%91%E8%80%85%E6%8C%87%E5%8D%97/%E5%8F%82%E4%B8%8E%E8%B4%A1%E7%8C%AE/pull_request before opening a pull request.-->

## Purpose of the pull request
将datasophon环境变量改成/opt/datasophon目录下组件的软链接路径，避免升级或者修改版本后需要手动修改环境变量
<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->
修改datasophon-worker/src/main/resources/script/datasophon-env.sh 去除版本信息，使用软链接路径

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

YES

This pull request is already covered by existing tests, such as *(please describe tests)*.

YES

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added datasophon-infrastructure tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

YES

If your pull request contains incompatible changes, you should also pull request the documentation to `https://github.com/datasophon/datasophon-website`
