### PR TITLE
[feature][api] 新增SeaTunnel Client

### DIFF
--- a/datasophon-api/src/main/resources/meta/DDP-1.2.2/SEATUNNEL/service_ddl.json
+++ b/datasophon-api/src/main/resources/meta/DDP-1.2.2/SEATUNNEL/service_ddl.json
@@ -1,0 +1,103 @@
+{
+  "name": "SEATUNNEL",
+  "label": "SeaTunnel",
+  "description": "数据同步工具",
+  "version": "2.3.4",
+  "sortNum": 32,
+  "dependencies": [],
+  "packageName": "apache-seatunnel-2.3.4-bin.tar.gz",
+  "decompressPackageName": "apache-seatunnel-2.3.4",
+  "roles": [
+    {
+      "name": "SeatunnelClient",
+      "label": "SeatunnelClient",
+      "roleType": "client",
+      "cardinality": "1+",
+      "logFile": "logs/seatunnel-client.log",
+      "resourceStrategies":[{
+        "type": "replace",
+        "source": "config/seatunnel-env.sh",
+        "regex":"\/opt\/spark",
+        "replacement": "/opt/datasophon/spark"
+      },{
+        "type": "replace",
+        "source": "config/seatunnel-env.sh",
+        "regex":"\/opt\/flink",
+        "replacement": "/opt/datasophon/flink"
+      },{
+        "type": "sh",
+        "commands": [["sh", "bin/install-plugin.sh", "2.3.4"]]
+      }]
+    }
+  ],
+  "configWriter": {
+    "generators": [
+      {
+        "filename": "seatunnel.yaml",
+        "configFormat": "custom",
+        "templateName": "seatunnel-yml.ftl",
+        "outputDirectory": "config",
+        "includeParams": [
+          "backupCount",
+          "custom.checkPoint"
+        ]
+      },
+      {
+        "filename": "hazelcast.yaml",
+        "configFormat": "custom",
+        "templateName": "hazelcast.ftl",
+        "outputDirectory": "config",
+        "includeParams": [
+          "hosts"
+        ]
+      },
+      {
+        "filename": "hazelcast-client.yaml",
+        "configFormat": "custom",
+        "templateName": "hazelcast-client.ftl",
+        "outputDirectory": "config",
+        "includeParams": [
+          "hosts"
+        ]
+      }
+    ]
+  },
+  "parameters": [
+    {
+      "name": "backupCount",
+      "label": "同步备份的数量",
+      "description": "同步备份的数量",
+      "required": true,
+      "type": "input",
+      "configType": "map",
+      "value": "1",
+      "configurableInWizard": true,
+      "hidden": false,
+      "defaultValue": "1"
+    },
+    {
+      "name": "custom.checkPoint",
+      "label": "自定义配置检查点存储",
+      "description": "自定义配置",
+      "configType": "custom",
+      "required": false,
+      "type": "multipleWithKey",
+      "value": [{"namespace":"/tmp/seatunnel/checkpoint_snapshot"},{"storage.type":"hdfs"},{"fs.defaultFS":"file:///tmp/"}],
+      "configurableInWizard": true,
+      "hidden": false,
+      "defaultValue": [{"namespace":"/tmp/seatunnel/checkpoint_snapshot"},{"storage.type":"hdfs"},{"fs.defaultFS":"file:///tmp/"}]
+    },
+    {
+      "name": "hosts",
+      "label": "集群节点ip",
+      "description": "集群节点ip",
+      "required": true,
+      "type": "multiple",
+      "separator": ",",
+      "value": [],
+      "configurableInWizard": true,
+      "hidden": false,
+      "defaultValue": ""
+    }
+  ]
+}

--- a/datasophon-worker/src/main/java/com/datasophon/worker/handler/InstallServiceHandler.java
+++ b/datasophon-worker/src/main/java/com/datasophon/worker/handler/InstallServiceHandler.java
@@ -102,6 +102,9 @@ public class InstallServiceHandler {
                             case LinkStrategy.LINK_TYPE:
                                 rs = BeanUtil.mapToBean(strategy, LinkStrategy.class, true, CopyOptions.create().ignoreError());
                                 break;
+                            case ShellStrategy.SHELL_TYPE:
+                                rs = BeanUtil.mapToBean(strategy, ShellStrategy.class, true, CopyOptions.create().ignoreError());
+                                break;
                             default:
                                 rs = new EmptyStrategy();
                         }

--- a/datasophon-worker/src/main/java/com/datasophon/worker/strategy/resource/ShellStrategy.java
+++ b/datasophon-worker/src/main/java/com/datasophon/worker/strategy/resource/ShellStrategy.java
@@ -1,0 +1,29 @@
+package com.datasophon.worker.strategy.resource;
+
+import com.datasophon.common.Constants;
+import com.datasophon.common.utils.ExecResult;
+import com.datasophon.common.utils.ShellUtils;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Collections;
+import java.util.List;
+
+@Slf4j
+@EqualsAndHashCode(callSuper = true)
+@Data
+public class ShellStrategy extends ResourceStrategy {
+
+    public static final String SHELL_TYPE = "sh";
+
+    private List<List<String>> commands;
+
+    @Override
+    public void exec() {
+        for (List<String> command : commands) {
+            ExecResult result = ShellUtils.execWithStatus(basePath, command, 60L);
+            log.info(" {} result {} ", command, result.getExecResult()? "success": "fail");
+        }
+    }
+}

--- a/datasophon-worker/src/main/resources/templates/hazelcast-client.ftl
+++ b/datasophon-worker/src/main/resources/templates/hazelcast-client.ftl
@@ -1,0 +1,11 @@
+hazelcast-client:
+  cluster-name: seatunnel
+  properties:
+    hazelcast.logging.type: log4j2
+  network:
+    cluster-members:
+<#list itemList as item>
+    <#list item.value?split(",") as host>
+      - ${host}:5801
+    </#list>
+</#list>

--- a/datasophon-worker/src/main/resources/templates/hazelcast.ftl
+++ b/datasophon-worker/src/main/resources/templates/hazelcast.ftl
@@ -1,0 +1,27 @@
+hazelcast:
+  cluster-name: seatunnel
+  network:
+    rest-api:
+      enabled: true
+      endpoint-groups:
+        CLUSTER_WRITE:
+          enabled: true
+        DATA:
+          enabled: true
+    join:
+      tcp-ip:
+        enabled: true
+        member-list:
+<#list itemList as item>
+    <#list item.value?split(",") as host>
+          - ${host}
+    </#list>
+</#list>
+    port:
+      auto-increment: false
+      port: 5801
+  properties:
+    hazelcast.invocation.max.retry.count: 20
+    hazelcast.tcp.join.port.try.count: 30
+    hazelcast.logging.type: log4j2
+    hazelcast.operation.generic.thread.count: 50

--- a/datasophon-worker/src/main/resources/templates/seatunnel-yml.ftl
+++ b/datasophon-worker/src/main/resources/templates/seatunnel-yml.ftl
@@ -1,0 +1,20 @@
+seatunnel:
+  engine:
+    backup-count: ${backupCount}
+    queue-type: blockingqueue
+    print-execution-info-interval: 60
+    print-job-metrics-info-interval: 60
+    slot-service:
+      dynamic-slot: true
+    checkpoint:
+      interval: 10000
+      timeout: 60000
+      max-concurrent: 1
+      tolerable-failure: 2
+      storage:
+        type: hdfs
+        max-retained: 3
+        plugin-config:
+          <#list itemList as item>
+          ${item.name}: ${item.value}
+          </#list>


### PR DESCRIPTION
SeaTunnel通过spark mode 和 flink mode运行

## Purpose of the pull request

implement for  #535

## Brief change log

新增SeaTunnel 
由于datasophon本身支持spark和flink,故不采用 seatunnel server模式

通过 `start-seatunnel-spark-3-connector-v2.sh` 使用spark模式
通过  `start-seatunnel-flink-15-connector-v2.sh` 使用flink模式

## Verify this pull request

This pull request is already tested in local env

