### PR TITLE
[bufix] 默认关闭kyuubi的spark动态分配, 因为会卡死

### DIFF
--- a/datasophon-api/src/main/resources/meta/DDP-1.2.2/KYUUBI/service_ddl.json
+++ b/datasophon-api/src/main/resources/meta/DDP-1.2.2/KYUUBI/service_ddl.json
@@ -237,7 +237,7 @@
       "description": "启用spark辅助shuffle服务",
       "required": true,
       "type": "switch",
-      "value": true,
+      "value": false,
       "configurableInWizard": true,
       "hidden": false,
       "defaultValue": true
@@ -259,7 +259,7 @@
       "description": "启用spark动态资源分配",
       "required": true,
       "type": "switch",
-      "value": true,
+      "value": false,
       "configurableInWizard": true,
       "hidden": false,
       "defaultValue": true


### PR DESCRIPTION
## Purpose of the pull request

fix kyuubi config

## Brief change log

默认关闭kyuubi的spark动态分配,  因为在测试时发现提交spark后会timeout, 无法完成查询

## Verify this pull request


This pull request is already covered by existing tests
