### PR TITLE
修复文档配置文件后缀

### DIFF
--- a/datasophon-worker/src/main/resources/templates/hadoop-env.ftl
+++ b/datasophon-worker/src/main/resources/templates/hadoop-env.ftl
@@ -30,8 +30,14 @@ export HDFS_JOURNALNODE_OPTS="$HDFS_JOURNALNODE_OPTS -javaagent:${hadoopHome}/jm
 export HDFS_ZKFC_OPTS="$HDFS_ZKFC_OPTS -javaagent:${hadoopHome}/jmx/jmx_prometheus_javaagent-0.16.1.jar=27004:${hadoopHome}/jmx/prometheus_config.yml"
 
 
-export YARN_RESOURCEMANAGER_OPTS="$YARN_RESOURCEMANAGER_OPTS -javaagent:${hadoopHome}/jmx/jmx_prometheus_javaagent-0.16.1.jar=9323:${hadoopHome}/jmx/prometheus_config.yml"
+if ! grep -q <<<"$YARN_RESOURCEMANAGER_OPTS" jmx_prometheus_javaagent; then
+YARN_RESOURCEMANAGER_OPTS="$YARN_RESOURCEMANAGER_OPTS -javaagent:${hadoopHome}/jmx/jmx_prometheus_javaagent-0.16.1.jar=9323:${hadoopHome}/jmx/prometheus_config.yml"
+fi
 
-export YARN_NODEMANAGER_OPTS="$YARN_NODEMANAGER_OPTS -javaagent:${hadoopHome}/jmx/jmx_prometheus_javaagent-0.16.1.jar=9324:${hadoopHome}/jmx/prometheus_config.yml"
+if ! grep -q <<<"$YARN_NODEMANAGER_OPTS" jmx_prometheus_javaagent; then
+YARN_NODEMANAGER_OPTS="$YARN_NODEMANAGER_OPTS -javaagent:${hadoopHome}/jmx/jmx_prometheus_javaagent-0.16.1.jar=9324:${hadoopHome}/jmx/prometheus_config.yml"
+fi
 
-export MAPRED_HISTORYSERVER_OPTS="$MAPRED_HISTORYSERVER_OPTS -javaagent:${hadoopHome}/jmx/jmx_prometheus_javaagent-0.16.1.jar=9325:${hadoopHome}/jmx/prometheus_config.yml"
+if ! grep -q <<<"$YARN_HISTORYSERVER_OPTS" jmx_prometheus_javaagent; then
+YARN_HISTORYSERVER_OPTS="$YARN_HISTORYSERVER_OPTS -javaagent:${hadoopHome}/jmx/jmx_prometheus_javaagent-0.16.1.jar=9325:${hadoopHome}/jmx/prometheus_config.yml"
+fi

--- a/docs/zh/datasophon集成clickhouse.md
+++ b/docs/zh/datasophon集成clickhouse.md
@@ -1761,7 +1761,7 @@ worker打包替换旧包
         "filename": "config.xml",
         "configFormat": "custom",
         "outputDirectory": "etc",
-        "templateName": "clickhouse-server-config.flt",
+        "templateName": "clickhouse-server-config.ftl",
         "includeParams": [
           "tcpPort",
           "shardAddress",
@@ -1772,7 +1772,7 @@ worker打包替换旧包
         "filename": "users.xml",
         "configFormat": "custom",
         "outputDirectory": "etc",
-        "templateName": "clickhouse-user.flt",
+        "templateName": "clickhouse-user.ftl",
         "includeParams": [
           "username",
           "password"


### PR DESCRIPTION
Fixed the clickhouse document configuration file suffixes