### PR TITLE
[Bug][Serivce][Major]Fix-停止、删除主机逻辑有误

### DIFF
--- a/datasophon-service/src/main/java/com/datasophon/api/enums/Status.java
+++ b/datasophon-service/src/main/java/com/datasophon/api/enums/Status.java
@@ -89,6 +89,7 @@ public enum Status {
     ODD_NUMBER_ARE_REQUIRED_FOR_DORISFE(10040, "The Number of DorisFE must be an odd number.", "DorisFE个数必须是奇数"),
     NO_SERVICE_ROLE_SELECTED(10041, "No service role selected", "未选择需要安装的服务实例"),
     TWO_KYUUBISERVERS_NEED_TO_BE_DEPLOYED(10042, "two kyuubiServer deployments are required", "KyuubiServer需要两个节点"),
+    HOST_EXIT_ONE_INSTALLED_ROLE(10043, "at least one role is installed on the host:", "主机上存在未删除的角色:"),
     ;
     
     private final int code;


### PR DESCRIPTION
<!--Thanks very much for contributing to DataSophon. Please review https://datasophon.github.io/datasophon-website/docs/current/%E5%BC%80%E5%8F%91%E8%80%85%E6%8C%87%E5%8D%97/%E5%8F%82%E4%B8%8E%E8%B4%A1%E7%8C%AE/pull_request before opening a pull request.-->

## Purpose of the pull request
针对 #595 ，修复停止、删除主机逻辑有误的bug
<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log
停止主机后，界面状态变更：
![企业微信截图_17235177393183](https://github.com/user-attachments/assets/bb622159-e163-49e4-89ef-71ed5ba08dfe)
停止服务后删除，提示报错：
![企业微信截图_17235179532464](https://github.com/user-attachments/assets/84c3be46-a0bb-4413-b6bd-cf791edc3f23)
删除主机后的界面：
![企业微信截图_17235180084169](https://github.com/user-attachments/assets/e2a5d97e-40dc-4cb1-aa39-491124347776)


## Verify this pull request

<!--*(Please pick either of the following options)*-->
This pull request is code cleanup without any test coverage.
