### PR TITLE
[Improvement][UI]优化新增角色组后，不显示新角色组的问题

### DIFF
--- a/datasophon-ui/src/pages/serviceManage/exampleList.vue
+++ b/datasophon-ui/src/pages/serviceManage/exampleList.vue
@@ -437,7 +437,10 @@ export default {
       let serviceId = { id: this.$route.params.serviceId || "" }
       let roleInstanceIds = this.selectedRowKeys
       let content = (
-        <AllotCharacter serviceId={serviceId} roleInstanceIds={roleInstanceIds} callBack={() => self.pollingSearch(), () => { this.selectedRowKeys = [] }} />
+        <AddCharacter serviceId={serviceId} callBack={() => {
+          self.pollingSearch();
+          self.getServiceRoleType()
+        }} />
       );
       this.$confirm({
         width: width,


### PR DESCRIPTION
<!--Thanks very much for contributing to DataSophon. Please review https://datasophon.github.io/datasophon-website/docs/current/%E5%BC%80%E5%8F%91%E8%80%85%E6%8C%87%E5%8D%97/%E5%8F%82%E4%B8%8E%E8%B4%A1%E7%8C%AE/pull_request before opening a pull request.-->

## Purpose of the pull request

当前问题：新增角色组成功后，选择角色组一栏中不会马上显示新增的角色组，需要刷新页面后才能看到新的角色组。

## Brief change log

新增角色组的回调函数中触发一次函数操作,更新角色组信息

