### PR TITLE
[BUG][UI]更改角色组配置时，切换角色组数据不更新，并且显示异常

### DIFF
--- a/datasophon-ui/src/pages/serviceManage/setting.vue
+++ b/datasophon-ui/src/pages/serviceManage/setting.vue
@@ -212,8 +212,9 @@ export default {
     },
     handlerClick(item,childIndex){
       console.log(item);
-      this.currentId = item.id  
-      this.getConfigVersion()
+      this.currentId = item.id;
+      this.getConfigVersion();
+      this.templateData = [];
     },
     handlearrayWithData(a) {
       let obj = {};


### PR DESCRIPTION
<!--Thanks very much for contributing to DataSophon. Please review https://datasophon.github.io/datasophon-website/docs/current/%E5%BC%80%E5%8F%91%E8%80%85%E6%8C%87%E5%8D%97/%E5%8F%82%E4%B8%8E%E8%B4%A1%E7%8C%AE/pull_request before opening a pull request.-->

## Purpose of the pull request

根据 #573 ，解决如下问题：角色组配置进行了修改未保存、修改后保存操作，切换角色组时，界面依旧显示的是修改的角色组配置项

