### PR TITLE
[BUG][Worker]服务配置的required设置为false不会写入配置文件

### DIFF
--- a/datasophon-worker/src/main/java/com/datasophon/worker/handler/ConfigureServiceHandler.java
+++ b/datasophon-worker/src/main/java/com/datasophon/worker/handler/ConfigureServiceHandler.java
@@ -118,9 +118,6 @@ public class ConfigureServiceHandler {
                     if (Constants.CUSTOM.equals(config.getConfigType())) {
                         addToCustomList(iterator, customConfList, config);
                     }
-                    if (!config.isRequired() && !Constants.CUSTOM.equals(config.getConfigType())) {
-                        iterator.remove();
-                    }
                     if (config.getValue() instanceof Boolean || config.getValue() instanceof Integer) {
                         logger.info("Convert boolean and integer to string");
                         config.setValue(config.getValue().toString());


### PR DESCRIPTION
<!--Thanks very much for contributing to DataSophon. Please review https://datasophon.github.io/datasophon-website/docs/current/%E5%BC%80%E5%8F%91%E8%80%85%E6%8C%87%E5%8D%97/%E5%8F%82%E4%B8%8E%E8%B4%A1%E7%8C%AE/pull_request before opening a pull request.-->

## Purpose of the pull request

修复：服务配置的required设置为false不会写入配置文件

## Brief change log

删除掉对isrequired的逻辑判断

