### PR TITLE
[bug][worker]角色首次运行是root权限会导致后续指定用户无法启动

### DIFF
--- a/datasophon-worker/src/main/java/com/datasophon/worker/handler/ServiceHandler.java
+++ b/datasophon-worker/src/main/java/com/datasophon/worker/handler/ServiceHandler.java
@@ -56,7 +56,7 @@ public class ServiceHandler {
     
     public ExecResult start(ServiceRoleRunner startRunner, ServiceRoleRunner statusRunner, String decompressPackageName,
                             RunAs runAs) {
-        ExecResult statusResult = execRunner(statusRunner, decompressPackageName, null);
+        ExecResult statusResult = execRunner(statusRunner, decompressPackageName, runAs);
         if (statusResult.getExecResult()) {
             logger.info("{} already started", decompressPackageName);
             ExecResult execResult = new ExecResult();


### PR DESCRIPTION
<!--Thanks very much for contributing to DataSophon. Please review https://datasophon.github.io/datasophon-website/docs/current/%E5%BC%80%E5%8F%91%E8%80%85%E6%8C%87%E5%8D%97/%E5%8F%82%E4%B8%8E%E8%B4%A1%E7%8C%AE/pull_request before opening a pull request.-->

## Purpose of the pull request

有的组件如：dinky，指定启动用户为dinky，但是在首次启动时，用于runas指定为null，则是root用户启动，导致启动后生成的pid文件和log文件的权限为root，后续再用dinky用户启动则权限错误。
## Brief change log

第一次启动传入runAs

