### PR TITLE
[BUG][UI]角色组新增或删除需要刷新界面才能更新

### DIFF
--- a/datasophon-ui/src/pages/serviceManage/exampleList.vue
+++ b/datasophon-ui/src/pages/serviceManage/exampleList.vue
@@ -184,6 +184,10 @@ export default {
   name: "exampleList",
   props: {
     serviceId: String,
+    tabKey: {
+      type: String,
+      required: true
+    }
   },
   provide () {
     return {
@@ -635,6 +639,9 @@ export default {
     },
   },
   watch: {
+    tabKey(newVal, oldVal) {
+      this.getServiceRoleType();
+    },
     logsVisible: {
       handler (val) {
         if (val) {

--- a/datasophon-ui/src/pages/serviceManage/index.vue
+++ b/datasophon-ui/src/pages/serviceManage/index.vue
@@ -30,10 +30,10 @@
         <OverViewPage :serviceId="serviceId" />
       </a-tab-pane>
       <a-tab-pane :key="2" tab="实例">
-        <ExampleList ref="ExampleListRef" :serviceId="serviceId" />
+        <ExampleList ref="ExampleListRef" :serviceId="serviceId" :tabKey="tabKey"/>
       </a-tab-pane>
       <a-tab-pane :key="3" tab="配置">
-        <Setting />
+        <Setting :tabKey="tabKey"/>
       </a-tab-pane>
       <a-tab-pane v-if="serviceName === 'YARN'" :key="4" tab="资源配置">
         <Queue />

--- a/datasophon-ui/src/pages/serviceManage/setting.vue
+++ b/datasophon-ui/src/pages/serviceManage/setting.vue
@@ -71,6 +71,10 @@ export default {
   components: { CommonTemplate },
   props: {
     steps4Data: Object,
+    tabKey: {
+      type: String,
+      required: true
+    }
   },
   data() {
     return {
@@ -411,6 +415,12 @@ export default {
       });
       return data;
     },
+  },
+  watch: {
+    // 监控 tabKey 的变化
+    tabKey(newVal, oldVal) {
+      this.getServiceRoleType();
+    }
   },
   created() {},
   mounted() {


### PR DESCRIPTION
<!--Thanks very much for contributing to DataSophon. Please review https://datasophon.github.io/datasophon-website/docs/current/%E5%BC%80%E5%8F%91%E8%80%85%E6%8C%87%E5%8D%97/%E5%8F%82%E4%B8%8E%E8%B4%A1%E7%8C%AE/pull_request before opening a pull request.-->

## Purpose of the pull request

1.在”实例”界面”新增角色组”后，前往“配置”界面无法查看到新增的角色组，需要刷新后才能显示。
2.在”配置”界面”删除角色组”后，前往”实例”界面”选择角色组”，角色组信息还是删除前的信息。

## Brief change log

切换标签后，重新获取数据
