### PR TITLE
[fix][service] 通过页面dfs.hosts配置的值创建白名单文件 (#622)

### DIFF
--- a/datasophon-worker/src/main/java/com/datasophon/worker/WorkerApplicationServer.java
+++ b/datasophon-worker/src/main/java/com/datasophon/worker/WorkerApplicationServer.java
@@ -106,6 +106,7 @@ public class WorkerApplicationServer {
     }
     
     private static void initUserMap(Map<String, String> userMap) {
+        userMap.put("hadoop", HADOOP);
         userMap.put("hdfs", HADOOP);
         userMap.put("yarn", HADOOP);
         userMap.put("hive", HADOOP);

--- a/datasophon-worker/src/main/resources/templates/xml.ftl
+++ b/datasophon-worker/src/main/resources/templates/xml.ftl
@@ -4,7 +4,15 @@
 <#list itemList as item>
     <property>
         <name>${item.name}</name>
+<#if item.value?contains("\\n")>
+        <value>
+<#list item.value?split("\\n") as line>
+            ${line}
+</#list>
+        </value>
+<#else>
         <value>${item.value}</value>
+</#if>
     </property>
 </#list>
 </configuration>


### PR DESCRIPTION
<!--Thanks very much for contributing to DataSophon. Please review https://datasophon.github.io/datasophon-website/docs/current/%E5%BC%80%E5%8F%91%E8%80%85%E6%8C%87%E5%8D%97/%E5%8F%82%E4%B8%8E%E8%B4%A1%E7%8C%AE/pull_request before opening a pull request.-->

## Purpose of the pull request

fix issue #622 修改创建namenode节点白名单、黑名单文件的路径优先通过页面变量配置获取，读取不到配置再写死文件路径

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added datasophon-infrastructure tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contains incompatible changes, you should also pull request the documentation to `https://github.com/datasophon/datasophon-website`
