### PR TITLE
[fix-649][admin] 修复主机Agent分发重试后进度条状态没有重置的问题

### DIFF
--- a/datasophon-service/src/main/java/com/datasophon/api/service/impl/InstallServiceImpl.java
+++ b/datasophon-service/src/main/java/com/datasophon/api/service/impl/InstallServiceImpl.java
@@ -366,8 +366,14 @@ public class InstallServiceImpl implements InstallService {
             
             hostInfo.setInstallState(InstallState.RUNNING);
             hostInfo.setInstallStateCode(InstallState.RUNNING.getValue());
+            hostInfo.setCreateTime(new Date());
             hostInfo.setErrMsg("");
             hostInfo.setProgress(0);
+
+            if (map != null) {
+                map.put(hostname, hostInfo);
+                CacheUtils.put(clusterCode + Constants.HOST_MAP, map);
+            }
             
             hostActor.tell(
                     new DispatcherHostAgentCommand(


### PR DESCRIPTION
## Purpose of the pull request

fix issue #649 集群管理-主机Agent分发-重试后进度条状态没有重置的问题

## Brief change log

在获取状态的接口dispatcherHostAgentList 中，当能够在cache中取到key时，是使用host的createtime与当前时间的时间差来判断是否超时，因此在重试接口中应该将host的createtime进行重置才能获取正确的状态。

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added datasophon-infrastructure tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contains incompatible changes, you should also pull request the documentation to `https://github.com/datasophon/datasophon-website`
